### PR TITLE
Add loongarch architecture support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ include stdlib/StdlibModules
 
 CAMLC = $(BOOT_OCAMLC) $(BOOT_STDLIBFLAGS) -use-prims runtime/primitives
 CAMLOPT=$(OCAMLRUN) ./ocamlopt$(EXE) $(STDLIBFLAGS) -I otherlibs/dynlink
-ARCHES=amd64 arm64 power s390x riscv
+ARCHES=amd64 arm64 power s390x riscv loongarch64
 VPATH = utils parsing typing bytecomp file_formats lambda middle_end \
   middle_end/closure middle_end/flambda middle_end/flambda/base_types \
   asmcomp driver toplevel tools

--- a/asmcomp/loongarch64/CSE.ml
+++ b/asmcomp/loongarch64/CSE.ml
@@ -1,0 +1,39 @@
+# 2 "asmcomp/loongarch64/CSE.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* CSE for the LoongArch *)
+
+open Arch
+open Mach
+open CSEgen
+
+class cse = object (_self)
+
+inherit cse_generic as super
+
+method! class_of_operation op =
+  match op with
+  | Ispecific(Imultaddf _ | Imultsubf _) -> Op_pure
+  | _ -> super#class_of_operation op
+
+method! is_cheap_operation op =
+  match op with
+  | Iconst_int n -> n <= 0x7FFF_FFFFn && n >= -0x8000_0000n
+  | _ -> false
+
+end
+
+let fundecl f =
+  (new cse)#fundecl f

--- a/asmcomp/loongarch64/NOTES.md
+++ b/asmcomp/loongarch64/NOTES.md
@@ -1,0 +1,13 @@
+# Supported platforms
+
+LoongArch in 64-bit mode
+
+Debian architecture name: `loongarch64`
+
+# Reference documents
+
+* Instruction set specification:
+  - https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
+
+* ELF ABI specification:
+  - https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html

--- a/asmcomp/loongarch64/arch.ml
+++ b/asmcomp/loongarch64/arch.ml
@@ -26,6 +26,7 @@ let command_line_options = []
 type specific_operation =
   | Imultaddf of bool        (* multiply, optionally negate, and add *)
   | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+  | Isqrtf                   (* floating-point square root *)
 
 (* Addressing modes *)
 
@@ -82,6 +83,9 @@ let print_specific_operation printreg op ppf arg =
   | Imultsubf true ->
       fprintf ppf "-f (%a *f %a -f %a)"
         printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Isqrtf ->
+      fprintf ppf "sqrtf %a"
+        printreg arg.(0)
 
 (* Specific operations that are pure *)
 

--- a/asmcomp/loongarch64/arch.ml
+++ b/asmcomp/loongarch64/arch.ml
@@ -1,0 +1,92 @@
+# 2 "asmcomp/loongarch64/arch.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Specific operations for the Loongarch processor *)
+
+open Format
+
+(* Machine-specific command-line options *)
+
+let command_line_options = []
+
+(* Specific operations *)
+
+type specific_operation =
+  | Imultaddf of bool        (* multiply, optionally negate, and add *)
+  | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+
+(* Addressing modes *)
+
+type addressing_mode =
+  | Iindexed of int                     (* reg + displ *)
+
+let is_immediate n =
+  (n <= 0x7FF) && (n >= -0x800)
+
+(* Sizes, endianness *)
+
+let big_endian = false
+
+let size_addr = 8
+let size_int = size_addr
+let size_float = 8
+
+let allow_unaligned_access = false
+
+(* Behavior of division *)
+
+let division_crashes_on_overflow = false
+
+(* Operations on addressing modes *)
+
+let identity_addressing = Iindexed 0
+
+let offset_addressing addr delta =
+  match addr with
+  | Iindexed n -> Iindexed(n + delta)
+
+let num_args_addressing = function
+  | Iindexed _ -> 1
+
+(* Printing operations and addressing modes *)
+
+let print_addressing printreg addr ppf arg =
+  match addr with
+  | Iindexed n ->
+      let idx = if n <> 0 then Printf.sprintf " + %i" n else "" in
+      fprintf ppf "%a%s" printreg arg.(0) idx
+
+let print_specific_operation printreg op ppf arg =
+  match op with
+  | Imultaddf false ->
+      fprintf ppf "%a *f %a +f %a"
+        printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Imultaddf true ->
+      fprintf ppf "-f (%a *f %a +f %a)"
+        printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Imultsubf false ->
+      fprintf ppf "%a *f %a -f %a"
+        printreg arg.(0) printreg arg.(1) printreg arg.(2)
+  | Imultsubf true ->
+      fprintf ppf "-f (%a *f %a -f %a)"
+        printreg arg.(0) printreg arg.(1) printreg arg.(2)
+
+(* Specific operations that are pure *)
+
+let operation_is_pure _ = true
+
+(* Specific operations that can raise *)
+
+let operation_can_raise _ = false

--- a/asmcomp/loongarch64/arch.mli
+++ b/asmcomp/loongarch64/arch.mli
@@ -1,0 +1,75 @@
+# 2 "asmcomp/loongarch64/arch.mli"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Specific operations for the LoongArch processor *)
+
+(* Machine-specific command-line options *)
+
+val command_line_options : (string * Arg.spec * string) list
+
+(* Specific operations *)
+
+type specific_operation =
+  | Imultaddf of bool        (* multiply, optionally negate, and add *)
+  | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+
+(* Addressing modes *)
+
+type addressing_mode =
+  | Iindexed of int                     (* reg + displ *)
+
+val is_immediate : int -> bool
+
+(* Sizes, endianness *)
+
+val big_endian : bool
+
+val size_addr : int
+
+val size_int : int
+
+val size_float : int
+
+val allow_unaligned_access : bool
+
+(* Behavior of division *)
+
+val division_crashes_on_overflow : bool
+
+(* Operations on addressing modes *)
+
+val identity_addressing : addressing_mode
+
+val offset_addressing : addressing_mode -> int -> addressing_mode
+
+val num_args_addressing : addressing_mode -> int
+
+(* Printing operations and addressing modes *)
+
+val print_addressing :
+  (Format.formatter -> 'a -> unit) -> addressing_mode ->
+  Format.formatter -> 'a array -> unit
+
+val print_specific_operation :
+  (Format.formatter -> 'a -> unit) -> specific_operation ->
+  Format.formatter -> 'a array -> unit
+
+(* Specific operations that are pure *)
+
+val operation_is_pure : specific_operation -> bool
+
+(* Specific operations that can raise *)
+
+val operation_can_raise : specific_operation -> bool

--- a/asmcomp/loongarch64/arch.mli
+++ b/asmcomp/loongarch64/arch.mli
@@ -24,6 +24,7 @@ val command_line_options : (string * Arg.spec * string) list
 type specific_operation =
   | Imultaddf of bool        (* multiply, optionally negate, and add *)
   | Imultsubf of bool        (* multiply, optionally negate, and subtract *)
+  | Isqrtf                   (* floating-point square root *)
 
 (* Addressing modes *)
 

--- a/asmcomp/loongarch64/emit.mlp
+++ b/asmcomp/loongarch64/emit.mlp
@@ -242,6 +242,7 @@ let name_for_intop_imm = function
 let name_for_floatop1 = function
   | Inegf -> "fneg.d"
   | Iabsf -> "fabs.d"
+  | Ispecific Isqrtf -> "fsqrt.d"
   | _ -> Misc.fatal_error "Emit.Iopf1"
 
 let name_for_floatop2 = function
@@ -256,6 +257,7 @@ let name_for_specific = function
   | Imultaddf true  -> "fnmadd.d"
   | Imultsubf false -> "fmsub.d"
   | Imultsubf true  -> "fnmsub.d"
+  | _ -> Misc.fatal_error "Emit.Iopf3"
 
 (* Output the assembly code for an instruction *)
 
@@ -492,7 +494,7 @@ let emit_instr env i =
           ` addi.d   {emit_reg reg_tmp2}, $zero, {emit_int n}\n {emit_string instr}    {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg reg_tmp2} \n`
       else
       `	{emit_string instri}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int n}\n`
-  | Lop(Inegf | Iabsf as op) ->
+  | Lop(Inegf | Iabsf | Ispecific Isqrtf as op) ->
       let instr = name_for_floatop1 op in
       `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
   | Lop(Iaddf | Isubf | Imulf | Idivf as op) ->

--- a/asmcomp/loongarch64/emit.mlp
+++ b/asmcomp/loongarch64/emit.mlp
@@ -1,0 +1,770 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Emission of LoongArch assembly code *)
+
+open Cmm
+open Arch
+open Proc
+open Reg
+open Mach
+open Linear
+open Emitaux
+open Emitenv
+
+(* Layout of the stack.  The stack is kept 16-aligned. *)
+
+let frame_size env =
+  let size =
+    env.stack_offset  +                    (* Trap frame, outgoing parameters *)
+    size_int * env.f.fun_num_stack_slots.(0) +    (* Local int variables *)
+    size_float * env.f.fun_num_stack_slots.(1)+  (* Local float variables *)
+    (if env.f.fun_contains_calls then size_addr else 0) (* Return address *)
+  in
+  Misc.align size 16
+
+let slot_offset env loc cls =
+  match loc with
+  | Local n ->
+      ("$sp",
+       if cls = 0
+       then env.stack_offset + env.f.fun_num_stack_slots.(1) * size_float
+            + n * size_int
+       else env.stack_offset + n * size_float)
+  | Incoming n ->
+      ("$sp", frame_size env + n)
+  | Outgoing n ->
+      ("$sp", n)
+  | Domainstate n ->
+      ("$s8", n + Domainstate.(idx_of_field Domain_extra_params) * 8)
+
+(* Output a symbol *)
+
+let emit_jump op s =
+  if !Clflags.dlcode || !Clflags.pic_code
+  then `{emit_string op}	%plt({emit_symbol s})`
+  else `{emit_string op}	{emit_symbol s}`
+
+let emit_call = emit_jump "bl"
+let emit_tail = emit_jump "b"
+
+(* Output a label *)
+
+let emit_label lbl =
+  emit_string ".L"; emit_int lbl
+
+(* Section switching *)
+
+let data_space =
+  ".section .data"
+
+let code_space =
+  ".section .text"
+
+let rodata_space =
+  ".section .rodata"
+
+(* Names for special regs *)
+
+let reg_tmp = phys_reg 22               (* t1 *)
+let reg_tmp2 = phys_reg 21              (* t0 *)
+let reg_t2 = phys_reg 13                (* t2 *)
+let reg_domain_state_ptr = phys_reg 25  (* s8 *)
+let reg_trap_ptr = phys_reg 23          (* s1 *)
+let reg_alloc_ptr = phys_reg 24         (* s7 *)
+let reg_stack_arg_begin = phys_reg 9    (* s3 *)
+let reg_stack_arg_end = phys_reg 10     (* s4 *)
+
+(* Output a pseudo-register *)
+
+let reg_name = function
+  | {loc = Reg r} -> register_name r
+  | _ -> Misc.fatal_error "Emit.reg_name"
+
+let emit_reg r =
+  emit_string (reg_name r)
+
+(* Adjust sp by the given byte amount, clobbers reg_tmp *)
+
+let emit_stack_adjustment n =
+  if n <> 0 then begin
+    if is_immediate n then
+      `        addi.d    $sp, $sp, {emit_int n} \n`
+    else begin
+      `        li.d      {emit_reg reg_tmp}, {emit_int n}\n`;
+      `        add.d     $sp, $sp, {emit_reg reg_tmp}\n`
+    end;
+    cfi_adjust_cfa_offset (-n)
+  end
+
+(* Output add.d-immediate instruction, clobbers reg_tmp2 *)
+
+let emit_addimm rd rs n =
+  if is_immediate n then
+    `	addi.d	{emit_reg rd}, {emit_reg rs}, {emit_int n}\n`
+  else begin
+    `	li.d	{emit_reg reg_tmp2}, {emit_int n}\n`;
+    `	add.d	{emit_reg rd}, {emit_reg rs}, {emit_reg reg_tmp2}\n`
+  end
+
+(* Output memory operation with a possibly non-immediate offset,
+   clobbers reg_tmp *)
+
+let emit_mem_op op reg ofs addr =
+  if is_immediate ofs then
+    `	{emit_string op}	{emit_string reg}, {emit_string addr}, {emit_int ofs}\n`
+  else begin
+    `	li.d	{emit_reg reg_tmp}, {emit_int ofs}\n`;
+    `	add.d	{emit_reg reg_tmp}, {emit_string addr}, {emit_reg reg_tmp}\n`;
+    `	{emit_string op}	{emit_string reg}, {emit_reg reg_tmp}, 0\n`
+  end
+
+let reload_ra n =
+  emit_mem_op "ld.d" "$ra" (n - 8) "$sp"
+
+let store_ra n =
+  emit_mem_op "st.d" "$ra" (n - 8) "$sp"
+
+let emit_store rs ofs rd =
+  emit_mem_op "st.d" (reg_name rs) ofs rd
+
+let emit_load rd ofs rs =
+  emit_mem_op "ld.d" (reg_name rd) ofs rs
+
+let emit_float_load rd ofs rs =
+  emit_mem_op "fld.d" (reg_name rd) ofs rs
+
+let emit_float_store rs ofs rd =
+  emit_mem_op "fst.d" (reg_name rs) ofs rd
+
+let emit_float_test cmp ~arg ~res =
+  let negated =
+    match cmp with
+    | CFneq | CFnlt | CFngt | CFnle | CFnge -> true
+    | CFeq | CFlt | CFgt | CFle | CFge -> false
+  in
+  begin match cmp with
+  | CFeq | CFneq -> `	fcmp.ceq.d	$fcc0, {emit_reg arg.(0)}, {emit_reg arg.(1)}\n     movcf2gr {emit_reg res}, $fcc0\n`
+  | CFlt | CFnlt -> `	fcmp.clt.d	$fcc0, {emit_reg arg.(0)}, {emit_reg arg.(1)}\n     movcf2gr {emit_reg res}, $fcc0\n`
+  | CFgt | CFngt -> `	fcmp.clt.d	$fcc0, {emit_reg arg.(1)}, {emit_reg arg.(0)}\n     movcf2gr {emit_reg res}, $fcc0\n`
+  | CFle | CFnle -> `	fcmp.cle.d	$fcc0, {emit_reg arg.(0)}, {emit_reg arg.(1)}\n     movcf2gr {emit_reg res}, $fcc0\n`
+  | CFge | CFnge -> `	fcmp.cle.d	$fcc0, {emit_reg arg.(1)}, {emit_reg arg.(0)}\n     movcf2gr {emit_reg res}, $fcc0\n`
+  end;
+  negated
+
+(* Record live pointers at call points *)
+
+let record_frame_label env live dbg =
+  let lbl = new_label () in
+  let live_offset = ref [] in
+  Reg.Set.iter
+    (function
+        {typ = Val; loc = Reg r} ->
+          live_offset := (r lsl 1) + 1 :: !live_offset
+      | {typ = Val; loc = Stack s} as reg ->
+          let (base, ofs) = slot_offset env s (register_class reg) in
+          assert (base = "$sp");
+          live_offset := ofs :: !live_offset
+      | {typ = Addr} as r ->
+          Misc.fatal_error ("bad GC root " ^ Reg.name r)
+      | _ -> ()
+    )
+    live;
+  record_frame_descr ~label:lbl ~frame_size:(frame_size env)
+    ~live_offset:!live_offset dbg;
+  lbl
+
+let record_frame env live dbg =
+  let lbl = record_frame_label env live dbg in
+  `{emit_label lbl}:\n`
+
+let emit_call_gc gc =
+  `{emit_label gc.gc_lbl}:\n`;
+  `	{emit_call "caml_call_gc"}\n`;
+  `{emit_label gc.gc_frame_lbl}:\n`;
+  `	b	{emit_label gc.gc_return_lbl}\n`
+
+let bound_error_label env dbg =
+  if !Clflags.debug || env.bound_error_sites = [] then begin
+    let lbl_bound_error = new_label() in
+    let lbl_frame = record_frame_label env Reg.Set.empty (Dbg_other dbg) in
+    env.bound_error_sites <-
+      { bd_lbl = lbl_bound_error;
+        bd_frame = lbl_frame; } :: env.bound_error_sites;
+    lbl_bound_error
+  end else
+    let bd = List.hd env.bound_error_sites in
+    bd.bd_lbl
+
+let emit_call_bound_error bd =
+  `{emit_label bd.bd_lbl}:\n`;
+  `	{emit_call "caml_ml_array_bound_error"}\n`;
+  `{emit_label bd.bd_frame}:\n`
+
+(* Names for various instructions *)
+
+let name_for_intop = function
+  | Iadd  -> "add.d"
+  | Isub  -> "sub.d"
+  | Imul  -> "mul.d"
+  | Imulh -> "mulh.d"
+  | Idiv  -> "div.d"
+  | Iand  -> "and"
+  | Ior   -> "or"
+  | Ixor  -> "xor"
+  | Ilsl  -> "sll.d"
+  | Ilsr  -> "srl.d"
+  | Iasr  -> "sra.d"
+  | Imod  -> "mod.d"
+  | _ -> Misc.fatal_error "Emit.Intop"
+
+let name_for_intop_imm = function
+  | Iadd -> "addi.d"
+  | Iand -> "andi"
+  | Ior  -> "ori"
+  | Ixor -> "xori"
+  | Ilsl -> "slli.d"
+  | Ilsr -> "srli.d"
+  | Iasr -> "srai.d"
+  | _ -> Misc.fatal_error "Emit.Intop_imm"
+
+let name_for_floatop1 = function
+  | Inegf -> "fneg.d"
+  | Iabsf -> "fabs.d"
+  | _ -> Misc.fatal_error "Emit.Iopf1"
+
+let name_for_floatop2 = function
+  | Iaddf -> "fadd.d"
+  | Isubf -> "fsub.d"
+  | Imulf -> "fmul.d"
+  | Idivf -> "fdiv.d"
+  | _ -> Misc.fatal_error "Emit.Iopf2"
+
+let name_for_specific = function
+  | Imultaddf false -> "fmadd.d"
+  | Imultaddf true  -> "fnmadd.d"
+  | Imultsubf false -> "fmsub.d"
+  | Imultsubf true  -> "fnmsub.d"
+
+(* Output the assembly code for an instruction *)
+
+let emit_instr env i =
+  emit_debug_info i.dbg;
+  match i.desc with
+    Lend -> ()
+  | Lprologue ->
+      assert (env.f.fun_prologue_required);
+      let n = frame_size env in
+      emit_stack_adjustment (-n);
+      if env.f.fun_contains_calls then begin
+        store_ra n;
+        cfi_offset ~reg:1 (* ra *) ~offset:(-8)
+      end;
+  | Lop(Imove | Ispill | Ireload) ->
+      let src = i.arg.(0) and dst = i.res.(0) in
+      if src.loc <> dst.loc then begin
+        match (src, dst) with
+        | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Reg _} ->
+            `	move      {emit_reg dst}, {emit_reg src}\n`
+        | {loc = Reg _; typ = Float}, {loc = Reg _; typ = Float} ->
+            `	fmov.d   {emit_reg dst}, {emit_reg src}\n`
+        | {loc = Reg _; typ = (Val | Int | Addr)}, {loc = Stack s} ->
+            let (base, ofs) = slot_offset env s (register_class dst) in
+            emit_store src ofs base
+        | {loc = Reg _; typ = Float}, {loc = Stack s} ->
+            let (base, ofs) = slot_offset env s (register_class dst) in
+            emit_float_store src ofs base
+        | {loc = Stack s; typ = (Val | Int | Addr)}, {loc = Reg _} ->
+            let (base, ofs) = slot_offset env s (register_class src) in
+            emit_load dst ofs base
+        | {loc = Stack s; typ = Float}, {loc = Reg _} ->
+            let (base, ofs) = slot_offset env s (register_class src) in
+            emit_float_load dst ofs base
+        | {loc = Reg _; typ = Float}, {loc = Reg _; typ = (Val | Int | Addr)}
+        | {loc = Stack _}, {loc = Stack _}
+        | {loc = Unknown}, _ | _, {loc = Unknown} ->
+            Misc.fatal_error "Emit: Imove"
+      end
+  | Lop(Iconst_int n) ->
+      `	li.d	{emit_reg i.res.(0)}, {emit_nativeint n}\n`
+  | Lop(Iconst_float f) ->
+      let lbl = new_label() in
+      env.float_literals <- {fl=f; lbl} :: env.float_literals;
+      `la.local {emit_reg reg_tmp}, {emit_label lbl} \n`;
+      `	fld.d	{emit_reg i.res.(0)}, {emit_reg reg_tmp}, 0\n`
+  | Lop(Iconst_symbol s) ->     (* FIXME la.global assert error in binutils*)
+      `pcaddi {emit_reg i.res.(0)}, 0 \n`;
+      `b 7112233f\n`;
+      `.dword {emit_symbol s}\n`;
+      `7112233: ld.d {emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 8\n`
+  | Lop(Icall_ind) ->
+      `	jirl	$ra, {emit_reg i.arg.(0)}, 0\n`;
+      record_frame env i.live (Dbg_other i.dbg)
+  | Lop(Icall_imm {func}) ->
+      `	{emit_call func}\n`;
+      record_frame env i.live (Dbg_other i.dbg)
+  | Lop(Itailcall_ind) ->
+      let n = frame_size env in
+      if env.f.fun_contains_calls then reload_ra n;
+      emit_stack_adjustment n;
+      `	jr	{emit_reg i.arg.(0)}\n`
+  | Lop(Itailcall_imm {func}) ->
+      if func = env.f.fun_name then begin
+        `	b	{emit_label env.f.fun_tailrec_entry_point_label}\n`
+      end else begin
+        let n = frame_size env in
+        if env.f.fun_contains_calls then reload_ra n;
+        emit_stack_adjustment n;
+        `	{emit_tail func}\n`
+      end
+  | Lop(Iextcall{func; alloc; stack_ofs}) ->
+      if stack_ofs > 0 then begin
+        `	move	{emit_reg reg_stack_arg_begin}, $sp\n`;
+        `	addi.d	{emit_reg reg_stack_arg_end}, $sp, {emit_int (Misc.align stack_ofs 16)}\n`;
+        `	la.global	{emit_reg reg_t2}, {emit_symbol func}\n`;
+        `	{emit_call "caml_c_call_stack_args"}\n`;
+        record_frame env i.live (Dbg_other i.dbg)
+      end else if alloc then begin
+        `	la.global	{emit_reg reg_t2}, {emit_symbol func}\n`;
+        `	{emit_call "caml_c_call"}\n`;
+        record_frame env i.live (Dbg_other i.dbg)
+      end else begin
+        (* store ocaml stack in s0, which is marked as being destroyed
+           at noalloc calls *)
+        `	move	$s0, $sp\n`;
+        cfi_remember_state ();
+        cfi_def_cfa_register ~reg:21;
+        let ofs = Domainstate.(idx_of_field Domain_c_stack) * 8 in
+        `	ld.d	$sp, {emit_reg reg_domain_state_ptr}, {emit_int ofs}\n`;
+        `	{emit_call func}\n`;
+        `	move	$sp, $s0\n`;
+        cfi_restore_state ()
+      end
+  | Lop(Istackoffset n) ->
+      assert (n mod 16 = 0);
+      emit_stack_adjustment (-n);
+      env.stack_offset <- env.stack_offset + n
+  | Lop(Iload { memory_chunk = Single; addressing_mode = Iindexed ofs; is_atomic } ) ->
+      assert (not is_atomic);
+      `	fld.s	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int ofs}\n`;
+      `	fcvt.d.s	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}\n`
+  | Lop(Iload { memory_chunk = Word_int | Word_val; addressing_mode = Iindexed ofs; is_atomic } ) ->
+      if is_atomic then `	dbar    0\n`;
+      `	ld.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int ofs}\n`;
+      if is_atomic then `	dbar    0\n`
+  | Lop(Iload { memory_chunk; addressing_mode = Iindexed ofs; is_atomic } ) ->
+      assert (not is_atomic);
+      let instr =
+        match memory_chunk with
+        | Byte_unsigned -> "ld.bu"
+        | Byte_signed -> "ld.b"
+        | Sixteen_unsigned -> "ld.hu"
+        | Sixteen_signed -> "ld.h"
+        | Thirtytwo_unsigned -> "ld.wu"
+        | Thirtytwo_signed -> "ld.w"
+        | Word_int | Word_val | Single -> assert false
+        | Double -> "fld.d"
+      in
+      `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int ofs}\n`
+  | Lop(Istore(Single, Iindexed ofs, _)) ->
+      (* ft0 is marked as destroyed for this operation *)
+      `	fcvt.s.d	$ft0, {emit_reg i.arg.(0)}\n`;
+      `	fst.s	$ft0, {emit_reg i.arg.(1)}, {emit_int ofs}\n`
+  | Lop(Istore((Word_int | Word_val), Iindexed ofs, assignement)) ->
+      if assignement then begin
+        `	dbar	0\n`;
+        `	st.d	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_int ofs}\n`
+      end else
+        `	st.d	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_int ofs}\n`;
+  | Lop(Istore(chunk, Iindexed ofs, _)) ->
+      let instr =
+        match chunk with
+        | Byte_unsigned | Byte_signed -> "st.b"
+        | Sixteen_unsigned | Sixteen_signed -> "st.h"
+        | Thirtytwo_unsigned | Thirtytwo_signed -> "st.w"
+        | Word_int | Word_val | Single -> assert false
+        | Double -> "fst.d"
+      in
+      `	{emit_string instr}	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_int ofs}\n`
+  | Lop(Ialloc {bytes; dbginfo}) ->
+      let lbl_frame_lbl = record_frame_label env i.live (Dbg_alloc dbginfo) in
+      if env.f.fun_fast then begin
+        let lbl_after_alloc = new_label () in
+        let lbl_call_gc = new_label () in
+        let n = -bytes in
+        let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+        emit_addimm reg_alloc_ptr reg_alloc_ptr n;
+        `	ld.d	{emit_reg reg_tmp}, {emit_reg reg_domain_state_ptr}, {emit_int offset}\n`;
+        `	bltu	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl_call_gc}\n`;
+        `{emit_label lbl_after_alloc}:\n`;
+        `	addi.d	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, 8\n`;
+        env.call_gc_sites <-
+          { gc_lbl = lbl_call_gc;
+            gc_return_lbl = lbl_after_alloc;
+            gc_frame_lbl = lbl_frame_lbl } :: env.call_gc_sites
+      end else begin
+        begin match bytes with
+        | 16 -> `	{emit_call "caml_alloc1"}\n`
+        | 24 -> `	{emit_call "caml_alloc2"}\n`
+        | 32 -> `	{emit_call "caml_alloc3"}\n`
+        | _  ->
+            `	li.d	{emit_reg reg_t2}, {emit_int bytes}\n`;
+            `	{emit_call "caml_allocN"}\n`
+        end;
+        `{emit_label lbl_frame_lbl}:\n`;
+        `	addi.d	{emit_reg i.res.(0)}, {emit_reg reg_alloc_ptr}, 8\n`
+      end
+  | Lop(Ipoll { return_label }) ->
+      let lbl_frame_lbl = record_frame_label env i.live (Dbg_alloc []) in
+      let lbl_after_poll = match return_label with
+                  | None -> new_label()
+                  | Some(lbl) -> lbl in
+      let lbl_call_gc = new_label () in
+      let offset = Domainstate.(idx_of_field Domain_young_limit) * 8 in
+      `	ld.d	{emit_reg reg_tmp}, {emit_reg reg_domain_state_ptr}, {emit_int offset}\n`;
+      begin match return_label with
+      | None -> `	bltu	{emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl_call_gc}\n`;
+                `{emit_label lbl_after_poll}:\n`;
+      | Some lbl -> ` bgeu  {emit_reg reg_alloc_ptr}, {emit_reg reg_tmp}, {emit_label lbl}\n`;
+                    ` b {emit_label lbl_call_gc}\n`
+      end;
+      env.call_gc_sites <-
+        { gc_lbl = lbl_call_gc;
+          gc_return_lbl = lbl_after_poll;
+          gc_frame_lbl = lbl_frame_lbl } :: env.call_gc_sites
+  | Lop(Iintop(Icomp cmp)) ->
+      begin match cmp with
+      | Isigned Clt ->
+          `	slt	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+      | Isigned Cge ->
+          `	slt	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+          `	xori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`;
+      | Isigned Cgt ->
+          `	slt	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
+      | Isigned Cle ->
+          `	slt	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`;
+          `	xori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`;
+      | Isigned Ceq | Iunsigned Ceq ->
+          `	sub.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+          `	sltui	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`
+      | Isigned Cne | Iunsigned Cne ->
+          `	sub.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+          `	sltu	{emit_reg i.res.(0)}, $zero, {emit_reg i.res.(0)}\n`
+      | Iunsigned Clt ->
+          `	sltu	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+      | Iunsigned Cge ->
+          `	sltu	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`;
+          `	xori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`;
+      | Iunsigned Cgt ->
+          `	sltu	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`
+      | Iunsigned Cle ->
+          `	sltu	{emit_reg i.res.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(0)}\n`;
+          `	xori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`;
+      end
+  | Lop(Icompf cmp) ->
+      let negated = emit_float_test cmp ~res:i.res.(0) ~arg:i.arg in
+      if negated then `	xori	{emit_reg i.res.(0)}, {emit_reg i.res.(0)}, 1\n`;
+  | Lop(Iintop (Icheckbound)) ->
+      let lbl = bound_error_label env i.dbg in
+      `	bleu	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_label lbl}\n`
+  | Lop(Iintop op) ->
+      let instr = name_for_intop op in
+      `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+  | Lop(Iintop_imm(Isub, n)) ->
+      `	addi.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int(-n)}\n`
+  | Lop(Iintop_imm(Iadd, n)) ->
+      `	addi.d	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int(n)}\n`
+  | Lop(Iintop_imm(op, n)) ->
+      let instri = name_for_intop_imm op in
+      if n<0 then  (* FIXME *)
+          let instr = name_for_intop op in
+          ` addi.d   {emit_reg reg_tmp2}, $zero, {emit_int n}\n {emit_string instr}    {emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg reg_tmp2} \n`
+      else
+      `	{emit_string instri}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_int n}\n`
+  | Lop(Inegf | Iabsf as op) ->
+      let instr = name_for_floatop1 op in
+      `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}\n`
+  | Lop(Iaddf | Isubf | Imulf | Idivf as op) ->
+      let instr = name_for_floatop2 op in
+      `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}\n`
+  | Lop(Ifloatofint) ->
+      ` movgr2fr.d  $ft0, {emit_reg i.arg.(0)} \n`;
+      `	ffint.d.l	{emit_reg i.res.(0)}, $ft0\n`
+  | Lop(Iintoffloat) ->
+      `	ftintrz.l.d	$ft0, {emit_reg i.arg.(0)}\n`;
+      ` movfr2gr.d  {emit_reg i.res.(0)}, $ft0 \n`
+  | Lop(Iopaque) ->
+      assert (i.arg.(0).loc = i.res.(0).loc)
+  | Lop(Ispecific sop) ->
+      let instr = name_for_specific sop in
+      `	{emit_string instr}	{emit_reg i.res.(0)}, {emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_reg i.arg.(2)}\n`
+  | Lop (Idls_get) ->
+      let ofs = Domainstate.(idx_of_field Domain_dls_root) * 8 in
+      `	ld.d	{emit_reg i.res.(0)}, {emit_reg reg_domain_state_ptr}, {emit_int ofs}\n`
+  | Lreloadretaddr ->
+      let n = frame_size env in
+      reload_ra n
+  | Lreturn ->
+      let n = frame_size env in
+      emit_stack_adjustment n;
+      `	jr  $ra\n`
+  | Llabel lbl ->
+      `{emit_label lbl}:\n`
+  | Lbranch lbl ->
+      `	b	{emit_label lbl}\n`
+  | Lcondbranch(tst, lbl) ->
+      begin match tst with
+      | Itruetest ->
+          `	bnez	{emit_reg i.arg.(0)}, {emit_label lbl}\n`
+      | Ifalsetest ->
+          `	beqz	{emit_reg i.arg.(0)}, {emit_label lbl}\n`
+      | Iinttest cmp ->
+          let name = match cmp with
+            | Iunsigned Ceq | Isigned Ceq -> "beq"
+            | Iunsigned Cne | Isigned Cne -> "bne"
+            | Iunsigned Cle -> "bleu" | Isigned Cle -> "ble"
+            | Iunsigned Cge -> "bgeu" | Isigned Cge -> "bge"
+            | Iunsigned Clt -> "bltu" | Isigned Clt -> "blt"
+            | Iunsigned Cgt -> "bgtu" | Isigned Cgt -> "bgt"
+          in
+          `	{emit_string name}	{emit_reg i.arg.(0)}, {emit_reg i.arg.(1)}, {emit_label lbl}\n`
+      | Iinttest_imm _ ->
+          Misc.fatal_error "Emit.emit_instr (Iinttest_imm _)"
+      | Ifloattest cmp ->
+          let negated = emit_float_test cmp ~arg:i.arg ~res:reg_tmp in
+          let branch =
+            if negated
+            then "beqz"
+            else "bnez"
+          in
+          `	{emit_string branch}	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      | Ioddtest ->
+          `	andi	{emit_reg reg_tmp}, {emit_reg i.arg.(0)}, 1\n`;
+          `	bnez	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      | Ieventest ->
+          `	andi	{emit_reg reg_tmp}, {emit_reg i.arg.(0)}, 1\n`;
+          `	beqz	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      end
+  | Lcondbranch3(lbl0, lbl1, lbl2) ->
+      `	addi.d	{emit_reg reg_tmp}, {emit_reg i.arg.(0)}, -1\n`;
+      begin match lbl0 with
+      | None -> ()
+      | Some lbl -> `	bltz	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      end;
+      begin match lbl1 with
+      | None -> ()
+      | Some lbl -> `	beqz	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      end;
+      begin match lbl2 with
+      | None -> ()
+      | Some lbl -> `	bgtz	{emit_reg reg_tmp}, {emit_label lbl}\n`
+      end
+  | Lswitch jumptbl ->
+      let lbl = new_label() in
+      `	la.local	{emit_reg reg_tmp}, {emit_label lbl}\n`;
+      `	slli.d	{emit_reg reg_tmp2}, {emit_reg i.arg.(0)}, 2\n`;
+      `	add.d	{emit_reg reg_tmp}, {emit_reg reg_tmp}, {emit_reg reg_tmp2}\n`;
+      `	jr	{emit_reg reg_tmp}\n`;
+      `{emit_label lbl}:\n`;
+      for i = 0 to Array.length jumptbl - 1 do
+        `	b	{emit_label jumptbl.(i)}\n`
+      done
+  | Lentertrap ->
+      ()
+  | Ladjust_trap_depth { delta_traps } ->
+      (* each trap occupes 16 bytes on the stack *)
+      let delta = 16 * delta_traps in
+      cfi_adjust_cfa_offset delta;
+      env.stack_offset <- env.stack_offset + delta
+  | Lpushtrap {lbl_handler} ->
+      `	la.local	{emit_reg reg_tmp}, {emit_label lbl_handler}\n`;
+      `	addi.d	$sp, $sp, -16\n`;
+      env.stack_offset <- env.stack_offset + 16;
+      `	st.d	{emit_reg reg_trap_ptr}, $sp, 0\n`;
+      `	st.d	{emit_reg reg_tmp}, $sp, 8\n`;
+      cfi_adjust_cfa_offset 16;
+      `	move	{emit_reg reg_trap_ptr}, $sp\n`
+  | Lpoptrap ->
+      `	ld.d	{emit_reg reg_trap_ptr}, $sp, 0\n`;
+      `	addi.d	$sp, $sp, 16\n`;
+      cfi_adjust_cfa_offset (-16);
+      env.stack_offset <- env.stack_offset - 16
+  | Lraise k ->
+      begin match k with
+      | Lambda.Raise_regular ->
+          `	{emit_call "caml_raise_exn"}\n`;
+          record_frame env Reg.Set.empty (Dbg_raise i.dbg)
+      | Lambda.Raise_reraise ->
+          `	{emit_call "caml_reraise_exn"}\n`;
+          record_frame env Reg.Set.empty (Dbg_raise i.dbg)
+      | Lambda.Raise_notrace ->
+          `	move	$sp, {emit_reg reg_trap_ptr}\n`;
+          `	ld.d	{emit_reg reg_tmp}, $sp, 8\n`;
+          `	ld.d	{emit_reg reg_trap_ptr}, $sp, 0\n`;
+          `	addi.d	$sp, $sp, 16\n`;
+          `	jr	{emit_reg reg_tmp}\n`
+      end
+
+(* Emit a sequence of instructions *)
+
+let rec emit_all env = function
+  | {desc = Lend} -> () | i -> emit_instr env i; emit_all env i.next
+
+(* Emission of a function declaration *)
+
+let fundecl fundecl =
+  let env = mk_env fundecl in
+  `	.globl	{emit_symbol fundecl.fun_name}\n`;
+  `	.type	{emit_symbol fundecl.fun_name}, @function\n`;
+  `	{emit_string code_space}\n`;
+  `	.align	2\n`;
+  `{emit_symbol fundecl.fun_name}:\n`;
+  emit_debug_info fundecl.fun_dbg;
+  cfi_startproc();
+
+  (* Dynamic stack checking *)
+  let stack_threshold_size = Config.stack_threshold * 8 in (* bytes *)
+  let { max_frame_size; contains_nontail_calls } =
+    preproc_stack_check
+      ~fun_body:fundecl.fun_body ~frame_size:(frame_size env) ~trap_size:16
+  in
+  let handle_overflow = ref None in
+  if contains_nontail_calls || max_frame_size >= stack_threshold_size then begin
+    let overflow = new_label () and ret = new_label () in
+    let threshold_offset = Domainstate.stack_ctx_words * 8 + stack_threshold_size in
+    let f = max_frame_size + threshold_offset in
+    let offset = Domainstate.(idx_of_field Domain_current_stack) * 8 in
+    `	ld.d	{emit_reg reg_tmp}, {emit_reg reg_domain_state_ptr}, {emit_int offset}\n`;
+    emit_addimm reg_tmp reg_tmp f;
+    `	bltu	$sp, {emit_reg reg_tmp}, {emit_label overflow}\n`;
+    `{emit_label ret}:\n`;
+    handle_overflow := Some (overflow, ret)
+  end;
+
+  emit_all env fundecl.fun_body;
+  List.iter emit_call_gc env.call_gc_sites;
+  List.iter emit_call_bound_error env.bound_error_sites;
+
+  begin match !handle_overflow with
+  | None -> ()
+  | Some (overflow, ret) ->
+      `{emit_label overflow}:\n`;
+      (* Pass the desired frame size on the stack, since all of the
+         argument-passing registers may be in use. *)
+      let s = Config.stack_threshold + max_frame_size / 8 in
+      `	li.d	{emit_reg reg_tmp}, {emit_int s}\n`;
+      `	addi.d	$sp, $sp, -16\n`;
+      `	st.d	{emit_reg reg_tmp}, $sp, 0\n`;
+      `	st.d	$ra, $sp, 8\n`;
+      `	{emit_call "caml_call_realloc_stack"}\n`;
+      `	ld.d	$ra, $sp, 8\n`;
+      `	addi.d	$sp, $sp, 16\n`;
+      `	b	{emit_label ret}\n`
+  end;
+
+  cfi_endproc();
+  `	.size	{emit_symbol fundecl.fun_name}, .-{emit_symbol fundecl.fun_name}\n`;
+  (* Emit the float literals *)
+  if env.float_literals <> [] then begin
+    `	{emit_string rodata_space}\n`;
+    `	.align	3\n`;
+    List.iter
+      (fun {fl; lbl} ->
+        `{emit_label lbl}:\n`;
+        emit_float64_directive ".quad" fl)
+      env.float_literals;
+  end
+
+(* Emission of data *)
+
+let declare_global_data s =
+  `	.globl	{emit_symbol s}\n`;
+  `	.type	{emit_symbol s}, @object\n`
+
+let emit_item = function
+  | Cglobal_symbol s ->
+      declare_global_data s
+  | Cdefine_symbol s ->
+      `{emit_symbol s}:\n`;
+  | Cint8 n ->
+      `	.byte	{emit_int n}\n`
+  | Cint16 n ->
+      `	.short	{emit_int n}\n`
+  | Cint32 n ->
+      `	.long	{emit_nativeint n}\n`
+  | Cint n ->
+      `	.quad	{emit_nativeint n}\n`
+  | Csingle f ->
+      emit_float32_directive ".long" (Int32.bits_of_float f)
+  | Cdouble f ->
+      emit_float64_directive ".quad" (Int64.bits_of_float f)
+  | Csymbol_address s ->
+      `	.quad	{emit_symbol s}\n`
+  | Cstring s ->
+      emit_bytes_directive "	.byte	" s
+  | Cskip n ->
+      if n > 0 then `	.space	{emit_int n}\n`
+  | Calign n ->
+      `	.align	{emit_int (Misc.log2 n)}\n`
+
+let data l =
+  `	{emit_string data_space}\n`;
+  List.iter emit_item l
+
+(* Beginning / end of an assembly file *)
+
+let begin_assembly() =
+  if !Clflags.dlcode || !Clflags.pic_code then `	\n`;  (* FIXME *)
+  `	.file \"\"\n`; (* PR#7073 *)
+  reset_debug_info ();
+  (* Emit the beginning of the segments *)
+  let lbl_begin = Compilenv.make_symbol (Some "data_begin") in
+  `	{emit_string data_space}\n`;
+  declare_global_data lbl_begin;
+  `{emit_symbol lbl_begin}:\n`;
+  let lbl_begin = Compilenv.make_symbol (Some "code_begin") in
+  `	{emit_string code_space}\n`;
+  declare_global_data lbl_begin;
+  `{emit_symbol lbl_begin}:\n`
+
+let end_assembly() =
+  `	{emit_string code_space}\n`;
+  let lbl_end = Compilenv.make_symbol (Some "code_end") in
+  declare_global_data lbl_end;
+  `{emit_symbol lbl_end}:\n`;
+  `	.long	0\n`;
+  `	{emit_string data_space}\n`;
+  let lbl_end = Compilenv.make_symbol (Some "data_end") in
+  declare_global_data lbl_end;
+  `    .quad   0\n`; (* PR#6329 *)
+  `{emit_symbol lbl_end}:\n`;
+  `	.quad	0\n`;
+  (* Emit the frame descriptors *)
+  `	{emit_string data_space}\n`; (* not rodata because relocations inside *)
+  let lbl = Compilenv.make_symbol (Some "frametable") in
+  declare_global_data lbl;
+  `{emit_symbol lbl}:\n`;
+  emit_frames
+    { efa_code_label = (fun l -> `	.quad	{emit_label l}\n`);
+      efa_data_label = (fun l -> `	.quad	{emit_label l}\n`);
+      efa_8 = (fun n -> `	.byte	{emit_int n}\n`);
+      efa_16 = (fun n -> `	.short	{emit_int n}\n`);
+      efa_32 = (fun n -> `	.long	{emit_int32 n}\n`);
+      efa_word = (fun n -> `	.quad	{emit_int n}\n`);
+      efa_align = (fun n -> `	.align	{emit_int (Misc.log2 n)}\n`);
+      efa_label_rel = (fun lbl ofs ->
+                           `	.long	({emit_label lbl} - .) + {emit_int32 ofs}\n`);
+      efa_def_label = (fun l -> `{emit_label l}:\n`);
+      efa_string = (fun s -> emit_bytes_directive "	.byte	" (s ^ "\000"))
+     }

--- a/asmcomp/loongarch64/proc.ml
+++ b/asmcomp/loongarch64/proc.ml
@@ -1,0 +1,315 @@
+# 2 "asmcomp/loongarch64/proc.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Description of the LoongArch *)
+
+open Misc
+open Cmm
+open Reg
+open Arch
+open Mach
+
+(* Instruction selection *)
+
+let word_addressed = false
+
+(* Registers available for register allocation *)
+
+(* Integer register map
+   --------------------
+
+    zero                   always zero
+    ra                     return address
+    sp, gp, tp             stack pointer, global pointer, thread pointer
+    a0-a7        0-7       arguments/results
+    s2-s6        8-12      arguments/results (preserved by C)
+    t2-t6        13-17     temporary
+    s0           18        general purpose (preserved by C)
+    t0, t1       19-20     temporaries (used by call veneers)
+    s1           21        trap pointer (preserved by C)
+    s7          22        allocation pointer (preserved by C)
+    s8          23        domain pointer (preserved by C)
+
+  Floating-point register map
+  ---------------------------
+
+    f0-f7    100-107     arguments
+    f0-f1    100-101     arguments/results
+    f8-f23   108-123     temporary
+    f24-f31  124-131     subroutine register variables
+
+  Additional notes
+  ----------------
+
+    - t1 is used by the code generator, so not available for register
+      allocation.
+
+    - t0-t6 may be used by PLT stubs, so should not be used to pass
+      arguments and may be clobbered by [Ialloc] in the presence of dynamic
+      linking.
+*)
+
+let int_reg_name =
+    [|"$a0"; "$a1"; "$a2"; "$a3"; "$a4"; "$a5"; "$a6"; "$a7";  (* 0- 7 *)
+      "$s2"; "$s3"; "$s4"; "$s5"; "$s6";                       (* 8-12*)
+      "$t2"; "$t3"; "$t4"; "$t5"; "$t6"; "$t7"; "$t8";          (*13-19*)
+      "$s0";                                                   (*20*)
+      "$t0"; "$t1";                                            (*21-22*)
+      "$s1"; "$s7"; "$s8";                                      (*23-25*)
+    |]
+
+let float_reg_name =
+  [| "$ft0"; "$ft1"; "$ft2"; "$ft3"; "$ft4"; "$ft5"; "$ft6";"$ft7";     (*100-107*)
+     "$fs0"; "$fs1";                                              (*108-109*)
+     "$fa0"; "$fa1"; "$fa2"; "$fa3"; "$fa4"; "$fa5"; "$fa6"; "$fa7";    (*110-117*)
+     "$fs2"; "$fs3"; "$fs4"; "$fs5"; "$fs6"; "$fs7";                  (*118-123*)
+     "$ft8"; "$ft9"; "$ft10"; "$ft11";"$ft12";"$ft13";"$ft14";"$ft15"; |] (*124-131*)
+let num_register_classes = 2
+
+let register_class r =
+  match r.typ with
+  | Val | Int | Addr -> 0
+  | Float -> 1
+
+(* first 19 int regs allocatable; all float regs allocatable *)
+let num_available_registers = [| 21; 32 |]
+
+let first_available_register = [| 0; 100 |]
+
+let register_name r =
+  if r < 100 then int_reg_name.(r) else float_reg_name.(r - 100)
+
+let rotate_registers = true
+
+(* Representation of hard registers by pseudo-registers *)
+
+let hard_int_reg =
+  let v = Array.make 26 Reg.dummy in
+  for i = 0 to 25 do
+    v.(i) <- Reg.at_location Int (Reg i)
+  done;
+  v
+
+let hard_float_reg =
+  let v = Array.make 32 Reg.dummy in
+  for i = 0 to 31 do
+    v.(i) <- Reg.at_location Float (Reg(100 + i))
+  done;
+  v
+
+let all_phys_regs =
+  Array.append hard_int_reg hard_float_reg
+
+let phys_reg n =
+  if n < 100 then hard_int_reg.(n) else hard_float_reg.(n - 100)
+
+let stack_slot slot ty =
+  Reg.at_location ty (Stack slot)
+
+(* Calling conventions *)
+
+let size_domainstate_args = 64 * size_int
+
+let calling_conventions
+    first_int last_int first_float last_float make_stack first_stack arg =
+  let loc = Array.make (Array.length arg) Reg.dummy in
+  let int = ref first_int in
+  let float = ref first_float in
+  let ofs = ref first_stack in
+  for i = 0 to Array.length arg - 1 do
+    match arg.(i) with
+    | Val | Int | Addr as ty ->
+        if !int <= last_int then begin
+          loc.(i) <- phys_reg !int;
+          incr int
+        end else begin
+          loc.(i) <- stack_slot (make_stack !ofs) ty;
+          ofs := !ofs + size_int
+        end
+    | Float ->
+        if !float <= last_float then begin
+          loc.(i) <- phys_reg !float;
+          incr float
+        end else begin
+          loc.(i) <- stack_slot (make_stack !ofs) Float;
+          ofs := !ofs + size_float
+        end
+  done;
+  (loc, Misc.align (max 0 !ofs) 16) (* Keep stack 16-aligned. *)
+
+let incoming ofs =
+  if ofs >= 0
+  then Incoming ofs
+  else Domainstate (ofs + size_domainstate_args)
+let outgoing ofs =
+  if ofs >= 0
+  then Outgoing ofs
+  else Domainstate (ofs + size_domainstate_args)
+let not_supported _ = fatal_error "Proc.loc_results: cannot call"
+
+let max_arguments_for_tailcalls = 13 (* in regs *) + 64 (* in domain state *)
+
+(* OCaml calling convention:
+     first integer args in a0 .. a7, s2 .. s6
+     first float args in fa0 .. fa7, fs2 .. fs9
+     remaining args in domain state area, then on stack.
+   Return values in a0 .. a7, s2 .. s6 or fa0 .. fa7, fs2 .. fs9. *)
+
+let loc_arguments arg =
+  calling_conventions 0 12 110 121 outgoing (- size_domainstate_args) arg
+
+let loc_parameters arg =
+  let (loc, _ofs) =
+    calling_conventions 0 12 110 121 incoming (- size_domainstate_args) arg
+  in
+  loc
+
+let loc_results res =
+  let (loc, _ofs) =
+    calling_conventions 0 12 110 121 not_supported 0 res
+  in
+  loc
+
+(* C calling convention:
+     first integer args in a0 .. a7
+     first float args in fa0 .. fa7
+     remaining args on stack.
+   A FP argument can be passed in an integer register if all FP registers
+   are exhausted but integer registers remain.
+   Return values in a0 .. a1 or fa0 .. fa1. *)
+
+let external_calling_conventions
+    first_int last_int first_float last_float make_stack arg =
+  let loc = Array.make (Array.length arg) [| Reg.dummy |] in
+  let int = ref first_int in
+  let float = ref first_float in
+  let ofs = ref 0 in
+  for i = 0 to Array.length arg - 1 do
+    match arg.(i) with
+    | Val | Int | Addr as ty ->
+        if !int <= last_int then begin
+          loc.(i) <- [| phys_reg !int |];
+          incr int
+        end else begin
+          loc.(i) <- [| stack_slot (make_stack !ofs) ty |];
+          ofs := !ofs + size_int
+        end
+    | Float ->
+        if !float <= last_float then begin
+          loc.(i) <- [| phys_reg !float |];
+          incr float
+        end else begin
+          loc.(i) <- [| stack_slot (make_stack !ofs) Float |];
+          ofs := !ofs + size_float
+        end
+  done;
+  (loc, Misc.align !ofs 16) (* Keep stack 16-aligned. *)
+
+let loc_external_arguments ty_args =
+  let arg = Cmm.machtype_of_exttype_list ty_args in
+  external_calling_conventions 0 7 110 117 outgoing arg
+
+let loc_external_results res =
+  let (loc, _ofs) = calling_conventions 0 1 110 111 not_supported 0 res
+  in loc
+
+(* Exceptions are in a0 *)
+
+let loc_exn_bucket = phys_reg 0
+
+(* Registers destroyed by operations *)
+
+let destroyed_at_c_noalloc_call =
+  (* s0-s8 and fs0-fs7 are callee-save, but s0 is
+     used to preserve OCaml sp. *)
+  Array.of_list(List.map phys_reg
+    [0; 1; 2; 3; 4; 5; 6; 7; 13; 14; 15; 16; 17; 18; 19; 20;(*s0*)
+     100; 101; 102; 103; 104; 105; 106; 107; 110; 111; 112; 113; 114; 115; 116;
+     117; 124; 125; 126; 127; 128; 129; 130; 131])
+
+let destroyed_at_alloc =
+  (* t0-t6 are used for PLT stubs *)
+    if !Clflags.dlcode then Array.map phys_reg [|13; 14; 15; 16; 17; 18; 19|]
+  else [| phys_reg 13 |] (* t2 is used to pass the argument to caml_allocN *)
+
+let destroyed_at_oper = function
+  | Iop(Icall_ind | Icall_imm _) -> all_phys_regs
+  | Iop(Iextcall{alloc; stack_ofs; _}) ->
+      assert (stack_ofs >= 0);
+      if alloc || stack_ofs > 0 then all_phys_regs
+      else destroyed_at_c_noalloc_call
+  | Iop(Ialloc _) | Iop(Ipoll _) -> destroyed_at_alloc
+  | Iop(Istore(Single, _, _)) -> [| phys_reg 100 |]
+  | Iop(Ifloatofint | Iintoffloat) -> [| phys_reg 100 |]
+  | _ -> [| |]
+
+let destroyed_at_raise = all_phys_regs
+
+let destroyed_at_reloadretaddr = [| |]
+
+(* Maximal register pressure *)
+
+let safe_register_pressure = function
+  | Iextcall _ -> 5  (*9-3 s0~s8 - s7 - s8 - s1 - s0*)
+  | _ -> 21
+
+let max_register_pressure = function
+  | Iextcall _ -> [| 5; 8 |] (* 6 integer callee-saves, 8 FP callee-saves *)
+  | _ -> [| 21; 30 |]
+
+(* Layout of the stack *)
+
+let frame_required fd =
+  fd.fun_contains_calls
+  || fd.fun_num_stack_slots.(0) > 0
+  || fd.fun_num_stack_slots.(1) > 0
+
+let prologue_required fd =
+  frame_required fd
+
+  (* FIXME *)
+let int_dwarf_reg_numbers =
+    [| 4; 5; 6; 7; 8; 9; 10; 11;
+     23; 24; 25; 26; 27; 28; 29; 30;
+     14; 15; 16; 17; 18;
+     31;
+     12; 13;
+     19; 20;
+  |]
+
+let float_dwarf_reg_numbers =
+  [| 32; 33; 34; 35; 36; 37; 38; 39;
+     40; 41;
+     42; 43; 44; 45; 46; 47; 48; 49;
+     50; 51; 52; 53; 54; 55; 56; 57;
+     58; 59;
+     60; 61; 62; 63;
+  |]
+
+let dwarf_register_numbers ~reg_class =
+  match reg_class with
+  | 0 -> int_dwarf_reg_numbers
+  | 1 -> float_dwarf_reg_numbers
+  | _ -> Misc.fatal_errorf "Bad register class %d" reg_class
+
+let stack_ptr_dwarf_register_number = 2
+
+(* Calling the assembler *)
+
+let assemble_file infile outfile =
+  Ccomp.command
+    (Config.asm ^ " -o " ^ Filename.quote outfile ^ " " ^ Filename.quote infile)
+
+let init () = ()

--- a/asmcomp/loongarch64/proc.ml
+++ b/asmcomp/loongarch64/proc.ml
@@ -71,11 +71,11 @@ let int_reg_name =
     |]
 
 let float_reg_name =
-  [| "$ft0"; "$ft1"; "$ft2"; "$ft3"; "$ft4"; "$ft5"; "$ft6";"$ft7";     (*100-107*)
-     "$fs0"; "$fs1";                                              (*108-109*)
-     "$fa0"; "$fa1"; "$fa2"; "$fa3"; "$fa4"; "$fa5"; "$fa6"; "$fa7";    (*110-117*)
-     "$fs2"; "$fs3"; "$fs4"; "$fs5"; "$fs6"; "$fs7";                  (*118-123*)
-     "$ft8"; "$ft9"; "$ft10"; "$ft11";"$ft12";"$ft13";"$ft14";"$ft15"; |] (*124-131*)
+  [| "$ft0"; "$ft1"; "$ft2"; "$ft3"; "$ft4"; "$ft5"; "$ft6";"$ft7";
+     "$fs0"; "$fs1";
+     "$fa0"; "$fa1"; "$fa2"; "$fa3"; "$fa4"; "$fa5"; "$fa6"; "$fa7";
+     "$fs2"; "$fs3"; "$fs4"; "$fs5"; "$fs6"; "$fs7";
+     "$ft8"; "$ft9"; "$ft10"; "$ft11";"$ft12";"$ft13";"$ft14";"$ft15"; |]
 let num_register_classes = 2
 
 let register_class r =

--- a/asmcomp/loongarch64/reload.ml
+++ b/asmcomp/loongarch64/reload.ml
@@ -1,0 +1,19 @@
+# 2 "asmcomp/loongarch64/reload.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Reloading for the LoongArch *)
+
+let fundecl f =
+  (new Reloadgen.reload_generic)#fundecl f

--- a/asmcomp/loongarch64/scheduling.ml
+++ b/asmcomp/loongarch64/scheduling.ml
@@ -1,0 +1,30 @@
+# 2 "asmcomp/loongarch64/scheduling.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Instruction scheduling for the LoongArch *)
+
+(* The "open!" directive below is necessary because, although
+   this module does not actually depend on Schedgen in this backend, the
+   dependency exists in other backends and our build system requires
+   that all the backends have the same dependencies.
+   We thus have to use "open!" and disable the corresponding warning
+   only for this compilation unit.
+*)
+
+open! Schedgen [@@warning "-66"]
+
+(* Scheduling is turned off. *)
+
+let fundecl f = f

--- a/asmcomp/loongarch64/selection.ml
+++ b/asmcomp/loongarch64/selection.ml
@@ -1,0 +1,68 @@
+# 2 "asmcomp/loongarch64/selection.ml"
+(**************************************************************************)
+(*                                                                        *)
+(*                                 OCaml                                  *)
+(*                                                                        *)
+(*                yala <zhaojunchao@loongson.cn>                          *)
+(*                                                                        *)
+(*               Copyright © 2008-2023 LOONGSON                           *)
+(*                                                                        *)
+(*   All rights reserved.  This file is distributed under the terms of    *)
+(*   the GNU Lesser General Public License version 2.1, with the          *)
+(*   special exception on linking described in the file LICENSE.          *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Instruction selection for the LoongArch processor *)
+
+open Cmm
+open Arch
+open Mach
+
+(* Instruction selection *)
+
+class selector = object
+
+inherit Selectgen.selector_generic as super
+
+(* LoongArch does not support immediate operands for comparison operators *)
+method is_immediate_test _cmp _n = false
+
+method! is_immediate op n =
+  match op with
+  | Iadd | Iand | Ior | Ixor -> is_immediate n
+  (* sub immediate is turned into add immediate opposite *)
+  | Isub -> is_immediate (-n)
+  | _ -> super#is_immediate op n
+
+method select_addressing _ = function
+  | Cop(Cadda, [arg; Cconst_int (n, _)], _) when is_immediate n ->
+      (Iindexed n, arg)
+  | Cop(Cadda, [arg1; Cop(Caddi, [arg2; Cconst_int (n, _)], _)], dbg)
+    when is_immediate n ->
+      (Iindexed n, Cop(Caddi, [arg1; arg2], dbg))
+  | arg ->
+      (Iindexed 0, arg)
+
+method! select_operation op args dbg =
+  match (op, args) with
+  (* Recognize (neg-)mult-add and (neg-)mult-sub instructions *)
+  | (Caddf, [Cop(Cmulf, [arg1; arg2], _); arg3])
+  | (Caddf, [arg3; Cop(Cmulf, [arg1; arg2], _)]) ->
+      (Ispecific (Imultaddf false), [arg1; arg2; arg3])
+  | (Csubf, [Cop(Cmulf, [arg1; arg2], _); arg3]) ->
+      (Ispecific (Imultsubf false), [arg1; arg2; arg3])
+  | (Cnegf, [Cop(Csubf, [Cop(Cmulf, [arg1; arg2], _); arg3], _)]) ->
+      (Ispecific (Imultsubf true), [arg1; arg2; arg3])
+  | (Cnegf, [Cop(Caddf, [Cop(Cmulf, [arg1; arg2], _); arg3], _)]) ->
+      (Ispecific (Imultaddf true), [arg1; arg2; arg3])
+  | (Cstore (Word_int | Word_val as memory_chunk, Assignment), [arg1; arg2]) ->
+      (* Use trivial addressing mode for non-initializing stores *)
+      (Istore (memory_chunk, Iindexed 0, true), [arg2; arg1])
+  | _ ->
+      super#select_operation op args dbg
+
+end
+
+let fundecl ~future_funcnames f =
+  (new selector)#emit_fundecl ~future_funcnames f

--- a/asmcomp/loongarch64/selection.ml
+++ b/asmcomp/loongarch64/selection.ml
@@ -59,6 +59,8 @@ method! select_operation op args dbg =
   | (Cstore (Word_int | Word_val as memory_chunk, Assignment), [arg1; arg2]) ->
       (* Use trivial addressing mode for non-initializing stores *)
       (Istore (memory_chunk, Iindexed 0, true), [arg2; arg1])
+  | (Cextcall("sqrt", _, _, _), []) ->
+          (Ispecific Isqrtf, args)
   | _ ->
       super#select_operation op args dbg
 

--- a/build-aux/config.guess
+++ b/build-aux/config.guess
@@ -1,12 +1,14 @@
 #! /bin/sh
 # Attempt to guess a canonical system name.
-#   Copyright 1992-2020 Free Software Foundation, Inc.
+#   Copyright 1992-2022 Free Software Foundation, Inc.
 
-timestamp='2020-07-12'
+# shellcheck disable=SC2006,SC2268 # see below for rationale
+
+timestamp='2022-09-17'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful, but
@@ -27,9 +29,17 @@ timestamp='2020-07-12'
 # Originally written by Per Bothner; maintained since 2000 by Ben Elliston.
 #
 # You can get the latest version of this script from:
-# https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess
+# https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
 #
 # Please send patches to <config-patches@gnu.org>.
+
+
+# The "shellcheck disable" line above the timestamp inhibits complaints
+# about features and limitations of the classic Bourne shell that were
+# superseded or lifted in POSIX.  However, this script identifies a wide
+# variety of pre-POSIX systems that do not have POSIX shells at all, and
+# even some reasonably current systems (Solaris 10 as case-in-point) still
+# have a pre-POSIX /bin/sh.
 
 
 me=`echo "$0" | sed -e 's,.*/,,'`
@@ -50,7 +60,7 @@ version="\
 GNU config.guess ($timestamp)
 
 Originally written by Per Bothner.
-Copyright 1992-2020 Free Software Foundation, Inc.
+Copyright 1992-2022 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
@@ -84,6 +94,9 @@ if test $# != 0; then
   exit 1
 fi
 
+# Just in case it came from the environment.
+GUESS=
+
 # CC_FOR_BUILD -- compiler used by this script. Note that the use of a
 # compiler to aid in system detection is discouraged as it requires
 # temporary files to be created and, as you can see below, it is a
@@ -102,7 +115,7 @@ set_cc_for_build() {
     # prevent multiple calls if $tmp is already set
     test "$tmp" && return 0
     : "${TMPDIR=/tmp}"
-    # shellcheck disable=SC2039
+    # shellcheck disable=SC2039,SC3028
     { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
 	{ test -n "$RANDOM" && tmp=$TMPDIR/cg$$-$RANDOM && (umask 077 && mkdir "$tmp" 2>/dev/null) ; } ||
 	{ tmp=$TMPDIR/cg-$$ && (umask 077 && mkdir "$tmp" 2>/dev/null) && echo "Warning: creating insecure temp directory" >&2 ; } ||
@@ -112,7 +125,7 @@ set_cc_for_build() {
 	,,)    echo "int x;" > "$dummy.c"
 	       for driver in cc gcc c89 c99 ; do
 		   if ($driver -c -o "$dummy.o" "$dummy.c") >/dev/null 2>&1 ; then
-		       CC_FOR_BUILD="$driver"
+		       CC_FOR_BUILD=$driver
 		       break
 		   fi
 	       done
@@ -133,14 +146,12 @@ fi
 
 UNAME_MACHINE=`(uname -m) 2>/dev/null` || UNAME_MACHINE=unknown
 UNAME_RELEASE=`(uname -r) 2>/dev/null` || UNAME_RELEASE=unknown
-UNAME_SYSTEM=`(uname -s) 2>/dev/null`  || UNAME_SYSTEM=unknown
+UNAME_SYSTEM=`(uname -s) 2>/dev/null` || UNAME_SYSTEM=unknown
 UNAME_VERSION=`(uname -v) 2>/dev/null` || UNAME_VERSION=unknown
 
-case "$UNAME_SYSTEM" in
+case $UNAME_SYSTEM in
 Linux|GNU|GNU/*)
-	# If the system lacks a compiler, then just pick glibc.
-	# We could probably try harder.
-	LIBC=gnu
+	LIBC=unknown
 
 	set_cc_for_build
 	cat <<-EOF > "$dummy.c"
@@ -149,24 +160,37 @@ Linux|GNU|GNU/*)
 	LIBC=uclibc
 	#elif defined(__dietlibc__)
 	LIBC=dietlibc
-	#else
+	#elif defined(__GLIBC__)
 	LIBC=gnu
+	#else
+	#include <stdarg.h>
+	/* First heuristic to detect musl libc.  */
+	#ifdef __DEFINED_va_list
+	LIBC=musl
+	#endif
 	#endif
 	EOF
-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`"
+	cc_set_libc=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^LIBC' | sed 's, ,,g'`
+	eval "$cc_set_libc"
 
-	# If ldd exists, use it to detect musl libc.
-	if command -v ldd >/dev/null && \
-		ldd --version 2>&1 | grep -q ^musl
-	then
-	    LIBC=musl
+	# Second heuristic to detect musl libc.
+	if [ "$LIBC" = unknown ] &&
+	   command -v ldd >/dev/null &&
+	   ldd --version 2>&1 | grep -q ^musl; then
+		LIBC=musl
+	fi
+
+	# If the system lacks a compiler, then just pick glibc.
+	# We could probably try harder.
+	if [ "$LIBC" = unknown ]; then
+		LIBC=gnu
 	fi
 	;;
 esac
 
 # Note: order is significant - the case branches are not exclusive.
 
-case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
+case $UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION in
     *:NetBSD:*:*)
 	# NetBSD (nbsd) targets should (where applicable) match one or
 	# more of the tuples: *-*-netbsdelf*, *-*-netbsdaout*,
@@ -178,12 +202,12 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	#
 	# Note: NetBSD doesn't particularly care about the vendor
 	# portion of the name.  We always set it to "unknown".
-	sysctl="sysctl -n hw.machine_arch"
 	UNAME_MACHINE_ARCH=`(uname -p 2>/dev/null || \
-	    "/sbin/$sysctl" 2>/dev/null || \
-	    "/usr/sbin/$sysctl" 2>/dev/null || \
+	    /sbin/sysctl -n hw.machine_arch 2>/dev/null || \
+	    /usr/sbin/sysctl -n hw.machine_arch 2>/dev/null || \
 	    echo unknown)`
-	case "$UNAME_MACHINE_ARCH" in
+	case $UNAME_MACHINE_ARCH in
+	    aarch64eb) machine=aarch64_be-unknown ;;
 	    armeb) machine=armeb-unknown ;;
 	    arm*) machine=arm-unknown ;;
 	    sh3el) machine=shl-unknown ;;
@@ -192,13 +216,13 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	    earmv*)
 		arch=`echo "$UNAME_MACHINE_ARCH" | sed -e 's,^e\(armv[0-9]\).*$,\1,'`
 		endian=`echo "$UNAME_MACHINE_ARCH" | sed -ne 's,^.*\(eb\)$,\1,p'`
-		machine="${arch}${endian}"-unknown
+		machine=${arch}${endian}-unknown
 		;;
-	    *) machine="$UNAME_MACHINE_ARCH"-unknown ;;
+	    *) machine=$UNAME_MACHINE_ARCH-unknown ;;
 	esac
 	# The Operating System including object format, if it has switched
 	# to ELF recently (or will in the future) and ABI.
-	case "$UNAME_MACHINE_ARCH" in
+	case $UNAME_MACHINE_ARCH in
 	    earm*)
 		os=netbsdelf
 		;;
@@ -219,7 +243,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 		;;
 	esac
 	# Determine ABI tags.
-	case "$UNAME_MACHINE_ARCH" in
+	case $UNAME_MACHINE_ARCH in
 	    earm*)
 		expr='s/^earmv[0-9]/-eabi/;s/eb$//'
 		abi=`echo "$UNAME_MACHINE_ARCH" | sed -e "$expr"`
@@ -230,7 +254,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# thus, need a distinct triplet. However, they do not need
 	# kernel version information, so it can be replaced with a
 	# suitable tag, in the style of linux-gnu.
-	case "$UNAME_VERSION" in
+	case $UNAME_VERSION in
 	    Debian*)
 		release='-gnu'
 		;;
@@ -241,51 +265,57 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# Since CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM:
 	# contains redundant information, the shorter form:
 	# CPU_TYPE-MANUFACTURER-OPERATING_SYSTEM is used.
-	echo "$machine-${os}${release}${abi-}"
-	exit ;;
+	GUESS=$machine-${os}${release}${abi-}
+	;;
     *:Bitrig:*:*)
 	UNAME_MACHINE_ARCH=`arch | sed 's/Bitrig.//'`
-	echo "$UNAME_MACHINE_ARCH"-unknown-bitrig"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE_ARCH-unknown-bitrig$UNAME_RELEASE
+	;;
     *:OpenBSD:*:*)
 	UNAME_MACHINE_ARCH=`arch | sed 's/OpenBSD.//'`
-	echo "$UNAME_MACHINE_ARCH"-unknown-openbsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE_ARCH-unknown-openbsd$UNAME_RELEASE
+	;;
+    *:SecBSD:*:*)
+	UNAME_MACHINE_ARCH=`arch | sed 's/SecBSD.//'`
+	GUESS=$UNAME_MACHINE_ARCH-unknown-secbsd$UNAME_RELEASE
+	;;
     *:LibertyBSD:*:*)
 	UNAME_MACHINE_ARCH=`arch | sed 's/^.*BSD\.//'`
-	echo "$UNAME_MACHINE_ARCH"-unknown-libertybsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE_ARCH-unknown-libertybsd$UNAME_RELEASE
+	;;
     *:MidnightBSD:*:*)
-	echo "$UNAME_MACHINE"-unknown-midnightbsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-midnightbsd$UNAME_RELEASE
+	;;
     *:ekkoBSD:*:*)
-	echo "$UNAME_MACHINE"-unknown-ekkobsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-ekkobsd$UNAME_RELEASE
+	;;
     *:SolidBSD:*:*)
-	echo "$UNAME_MACHINE"-unknown-solidbsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-solidbsd$UNAME_RELEASE
+	;;
     *:OS108:*:*)
-	echo "$UNAME_MACHINE"-unknown-os108_"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-os108_$UNAME_RELEASE
+	;;
     macppc:MirBSD:*:*)
-	echo powerpc-unknown-mirbsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=powerpc-unknown-mirbsd$UNAME_RELEASE
+	;;
     *:MirBSD:*:*)
-	echo "$UNAME_MACHINE"-unknown-mirbsd"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-mirbsd$UNAME_RELEASE
+	;;
     *:Sortix:*:*)
-	echo "$UNAME_MACHINE"-unknown-sortix
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-sortix
+	;;
     *:Twizzler:*:*)
-	echo "$UNAME_MACHINE"-unknown-twizzler
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-twizzler
+	;;
     *:Redox:*:*)
-	echo "$UNAME_MACHINE"-unknown-redox
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-redox
+	;;
     mips:OSF1:*.*)
-	echo mips-dec-osf1
-	exit ;;
+	GUESS=mips-dec-osf1
+	;;
     alpha:OSF1:*:*)
+	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
+	trap '' 0
 	case $UNAME_RELEASE in
 	*4.0)
 		UNAME_RELEASE=`/usr/sbin/sizer -v | awk '{print $3}'`
@@ -299,7 +329,7 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# covers most systems running today.  This code pipes the CPU
 	# types through head -n 1, so we only detect the type of CPU 0.
 	ALPHA_CPU_TYPE=`/usr/sbin/psrinfo -v | sed -n -e 's/^  The alpha \(.*\) processor.*$/\1/p' | head -n 1`
-	case "$ALPHA_CPU_TYPE" in
+	case $ALPHA_CPU_TYPE in
 	    "EV4 (21064)")
 		UNAME_MACHINE=alpha ;;
 	    "EV4.5 (21064)")
@@ -336,117 +366,121 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
 	# A Tn.n version is a released field test version.
 	# A Xn.n version is an unreleased experimental baselevel.
 	# 1.2 uses "1.2" for uname -r.
-	echo "$UNAME_MACHINE"-dec-osf"`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`"
-	# Reset EXIT trap before exiting to avoid spurious non-zero exit code.
-	exitcode=$?
-	trap '' 0
-	exit $exitcode ;;
+	OSF_REL=`echo "$UNAME_RELEASE" | sed -e 's/^[PVTX]//' | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
+	GUESS=$UNAME_MACHINE-dec-osf$OSF_REL
+	;;
     Amiga*:UNIX_System_V:4.0:*)
-	echo m68k-unknown-sysv4
-	exit ;;
+	GUESS=m68k-unknown-sysv4
+	;;
     *:[Aa]miga[Oo][Ss]:*:*)
-	echo "$UNAME_MACHINE"-unknown-amigaos
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-amigaos
+	;;
     *:[Mm]orph[Oo][Ss]:*:*)
-	echo "$UNAME_MACHINE"-unknown-morphos
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-morphos
+	;;
     *:OS/390:*:*)
-	echo i370-ibm-openedition
-	exit ;;
+	GUESS=i370-ibm-openedition
+	;;
     *:z/VM:*:*)
-	echo s390-ibm-zvmoe
-	exit ;;
+	GUESS=s390-ibm-zvmoe
+	;;
     *:OS400:*:*)
-	echo powerpc-ibm-os400
-	exit ;;
+	GUESS=powerpc-ibm-os400
+	;;
     arm:RISC*:1.[012]*:*|arm:riscix:1.[012]*:*)
-	echo arm-acorn-riscix"$UNAME_RELEASE"
-	exit ;;
+	GUESS=arm-acorn-riscix$UNAME_RELEASE
+	;;
     arm*:riscos:*:*|arm*:RISCOS:*:*)
-	echo arm-unknown-riscos
-	exit ;;
+	GUESS=arm-unknown-riscos
+	;;
     SR2?01:HI-UX/MPP:*:* | SR8000:HI-UX/MPP:*:*)
-	echo hppa1.1-hitachi-hiuxmpp
-	exit ;;
+	GUESS=hppa1.1-hitachi-hiuxmpp
+	;;
     Pyramid*:OSx*:*:* | MIS*:OSx*:*:* | MIS*:SMP_DC-OSx*:*:*)
 	# akee@wpdis03.wpafb.af.mil (Earle F. Ake) contributed MIS and NILE.
-	if test "`(/bin/universe) 2>/dev/null`" = att ; then
-		echo pyramid-pyramid-sysv3
-	else
-		echo pyramid-pyramid-bsd
-	fi
-	exit ;;
+	case `(/bin/universe) 2>/dev/null` in
+	    att) GUESS=pyramid-pyramid-sysv3 ;;
+	    *)   GUESS=pyramid-pyramid-bsd   ;;
+	esac
+	;;
     NILE*:*:*:dcosx)
-	echo pyramid-pyramid-svr4
-	exit ;;
+	GUESS=pyramid-pyramid-svr4
+	;;
     DRS?6000:unix:4.0:6*)
-	echo sparc-icl-nx6
-	exit ;;
+	GUESS=sparc-icl-nx6
+	;;
     DRS?6000:UNIX_SV:4.2*:7* | DRS?6000:isis:4.2*:7*)
 	case `/usr/bin/uname -p` in
-	    sparc) echo sparc-icl-nx7; exit ;;
-	esac ;;
+	    sparc) GUESS=sparc-icl-nx7 ;;
+	esac
+	;;
     s390x:SunOS:*:*)
-	echo "$UNAME_MACHINE"-ibm-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=$UNAME_MACHINE-ibm-solaris2$SUN_REL
+	;;
     sun4H:SunOS:5.*:*)
-	echo sparc-hal-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=sparc-hal-solaris2$SUN_REL
+	;;
     sun4*:SunOS:5.*:* | tadpole*:SunOS:5.*:*)
-	echo sparc-sun-solaris2"`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=sparc-sun-solaris2$SUN_REL
+	;;
     i86pc:AuroraUX:5.*:* | i86xen:AuroraUX:5.*:*)
-	echo i386-pc-auroraux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=i386-pc-auroraux$UNAME_RELEASE
+	;;
     i86pc:SunOS:5.*:* | i86xen:SunOS:5.*:*)
 	set_cc_for_build
 	SUN_ARCH=i386
 	# If there is a compiler, see if it is configured for 64-bit objects.
 	# Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
 	# This test works for both compilers.
-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
+	if test "$CC_FOR_BUILD" != no_compiler_found; then
 	    if (echo '#ifdef __amd64'; echo IS_64BIT_ARCH; echo '#endif') | \
-		(CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+		(CCOPTS="" $CC_FOR_BUILD -m64 -E - 2>/dev/null) | \
 		grep IS_64BIT_ARCH >/dev/null
 	    then
 		SUN_ARCH=x86_64
 	    fi
 	fi
-	echo "$SUN_ARCH"-pc-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=$SUN_ARCH-pc-solaris2$SUN_REL
+	;;
     sun4*:SunOS:6*:*)
 	# According to config.sub, this is the proper way to canonicalize
 	# SunOS6.  Hard to guess exactly what SunOS6 will be like, but
 	# it's likely to be more like Solaris than SunOS4.
-	echo sparc-sun-solaris3"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=sparc-sun-solaris3$SUN_REL
+	;;
     sun4*:SunOS:*:*)
-	case "`/usr/bin/arch -k`" in
+	case `/usr/bin/arch -k` in
 	    Series*|S4*)
 		UNAME_RELEASE=`uname -v`
 		;;
 	esac
 	# Japanese Language versions have a version number like `4.1.3-JL'.
-	echo sparc-sun-sunos"`echo "$UNAME_RELEASE"|sed -e 's/-/_/'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/-/_/'`
+	GUESS=sparc-sun-sunos$SUN_REL
+	;;
     sun3*:SunOS:*:*)
-	echo m68k-sun-sunos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-sun-sunos$UNAME_RELEASE
+	;;
     sun*:*:4.2BSD:*)
 	UNAME_RELEASE=`(sed 1q /etc/motd | awk '{print substr($5,1,3)}') 2>/dev/null`
 	test "x$UNAME_RELEASE" = x && UNAME_RELEASE=3
-	case "`/bin/arch`" in
+	case `/bin/arch` in
 	    sun3)
-		echo m68k-sun-sunos"$UNAME_RELEASE"
+		GUESS=m68k-sun-sunos$UNAME_RELEASE
 		;;
 	    sun4)
-		echo sparc-sun-sunos"$UNAME_RELEASE"
+		GUESS=sparc-sun-sunos$UNAME_RELEASE
 		;;
 	esac
-	exit ;;
+	;;
     aushp:SunOS:*:*)
-	echo sparc-auspex-sunos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sparc-auspex-sunos$UNAME_RELEASE
+	;;
     # The situation for MiNT is a little confusing.  The machine name
     # can be virtually everything (everything which is not
     # "atarist" or "atariste" at least should have a processor
@@ -456,41 +490,41 @@ case "$UNAME_MACHINE:$UNAME_SYSTEM:$UNAME_RELEASE:$UNAME_VERSION" in
     # MiNT.  But MiNT is downward compatible to TOS, so this should
     # be no problem.
     atarist[e]:*MiNT:*:* | atarist[e]:*mint:*:* | atarist[e]:*TOS:*:*)
-	echo m68k-atari-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-atari-mint$UNAME_RELEASE
+	;;
     atari*:*MiNT:*:* | atari*:*mint:*:* | atarist[e]:*TOS:*:*)
-	echo m68k-atari-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-atari-mint$UNAME_RELEASE
+	;;
     *falcon*:*MiNT:*:* | *falcon*:*mint:*:* | *falcon*:*TOS:*:*)
-	echo m68k-atari-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-atari-mint$UNAME_RELEASE
+	;;
     milan*:*MiNT:*:* | milan*:*mint:*:* | *milan*:*TOS:*:*)
-	echo m68k-milan-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-milan-mint$UNAME_RELEASE
+	;;
     hades*:*MiNT:*:* | hades*:*mint:*:* | *hades*:*TOS:*:*)
-	echo m68k-hades-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-hades-mint$UNAME_RELEASE
+	;;
     *:*MiNT:*:* | *:*mint:*:* | *:*TOS:*:*)
-	echo m68k-unknown-mint"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-unknown-mint$UNAME_RELEASE
+	;;
     m68k:machten:*:*)
-	echo m68k-apple-machten"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-apple-machten$UNAME_RELEASE
+	;;
     powerpc:machten:*:*)
-	echo powerpc-apple-machten"$UNAME_RELEASE"
-	exit ;;
+	GUESS=powerpc-apple-machten$UNAME_RELEASE
+	;;
     RISC*:Mach:*:*)
-	echo mips-dec-mach_bsd4.3
-	exit ;;
+	GUESS=mips-dec-mach_bsd4.3
+	;;
     RISC*:ULTRIX:*:*)
-	echo mips-dec-ultrix"$UNAME_RELEASE"
-	exit ;;
+	GUESS=mips-dec-ultrix$UNAME_RELEASE
+	;;
     VAX*:ULTRIX*:*:*)
-	echo vax-dec-ultrix"$UNAME_RELEASE"
-	exit ;;
+	GUESS=vax-dec-ultrix$UNAME_RELEASE
+	;;
     2020:CLIX:*:* | 2430:CLIX:*:*)
-	echo clipper-intergraph-clix"$UNAME_RELEASE"
-	exit ;;
+	GUESS=clipper-intergraph-clix$UNAME_RELEASE
+	;;
     mips:*:*:UMIPS | mips:*:*:RISCos)
 	set_cc_for_build
 	sed 's/^	//' << EOF > "$dummy.c"
@@ -518,75 +552,76 @@ EOF
 	  dummyarg=`echo "$UNAME_RELEASE" | sed -n 's/\([0-9]*\).*/\1/p'` &&
 	  SYSTEM_NAME=`"$dummy" "$dummyarg"` &&
 	    { echo "$SYSTEM_NAME"; exit; }
-	echo mips-mips-riscos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=mips-mips-riscos$UNAME_RELEASE
+	;;
     Motorola:PowerMAX_OS:*:*)
-	echo powerpc-motorola-powermax
-	exit ;;
+	GUESS=powerpc-motorola-powermax
+	;;
     Motorola:*:4.3:PL8-*)
-	echo powerpc-harris-powermax
-	exit ;;
+	GUESS=powerpc-harris-powermax
+	;;
     Night_Hawk:*:*:PowerMAX_OS | Synergy:PowerMAX_OS:*:*)
-	echo powerpc-harris-powermax
-	exit ;;
+	GUESS=powerpc-harris-powermax
+	;;
     Night_Hawk:Power_UNIX:*:*)
-	echo powerpc-harris-powerunix
-	exit ;;
+	GUESS=powerpc-harris-powerunix
+	;;
     m88k:CX/UX:7*:*)
-	echo m88k-harris-cxux7
-	exit ;;
+	GUESS=m88k-harris-cxux7
+	;;
     m88k:*:4*:R4*)
-	echo m88k-motorola-sysv4
-	exit ;;
+	GUESS=m88k-motorola-sysv4
+	;;
     m88k:*:3*:R3*)
-	echo m88k-motorola-sysv3
-	exit ;;
+	GUESS=m88k-motorola-sysv3
+	;;
     AViiON:dgux:*:*)
 	# DG/UX returns AViiON for all architectures
 	UNAME_PROCESSOR=`/usr/bin/uname -p`
-	if [ "$UNAME_PROCESSOR" = mc88100 ] || [ "$UNAME_PROCESSOR" = mc88110 ]
+	if test "$UNAME_PROCESSOR" = mc88100 || test "$UNAME_PROCESSOR" = mc88110
 	then
-	    if [ "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx ] || \
-	       [ "$TARGET_BINARY_INTERFACE"x = x ]
+	    if test "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx || \
+	       test "$TARGET_BINARY_INTERFACE"x = x
 	    then
-		echo m88k-dg-dgux"$UNAME_RELEASE"
+		GUESS=m88k-dg-dgux$UNAME_RELEASE
 	    else
-		echo m88k-dg-dguxbcs"$UNAME_RELEASE"
+		GUESS=m88k-dg-dguxbcs$UNAME_RELEASE
 	    fi
 	else
-	    echo i586-dg-dgux"$UNAME_RELEASE"
+	    GUESS=i586-dg-dgux$UNAME_RELEASE
 	fi
-	exit ;;
+	;;
     M88*:DolphinOS:*:*)	# DolphinOS (SVR3)
-	echo m88k-dolphin-sysv3
-	exit ;;
+	GUESS=m88k-dolphin-sysv3
+	;;
     M88*:*:R3*:*)
 	# Delta 88k system running SVR3
-	echo m88k-motorola-sysv3
-	exit ;;
+	GUESS=m88k-motorola-sysv3
+	;;
     XD88*:*:*:*) # Tektronix XD88 system running UTekV (SVR3)
-	echo m88k-tektronix-sysv3
-	exit ;;
+	GUESS=m88k-tektronix-sysv3
+	;;
     Tek43[0-9][0-9]:UTek:*:*) # Tektronix 4300 system running UTek (BSD)
-	echo m68k-tektronix-bsd
-	exit ;;
+	GUESS=m68k-tektronix-bsd
+	;;
     *:IRIX*:*:*)
-	echo mips-sgi-irix"`echo "$UNAME_RELEASE"|sed -e 's/-/_/g'`"
-	exit ;;
+	IRIX_REL=`echo "$UNAME_RELEASE" | sed -e 's/-/_/g'`
+	GUESS=mips-sgi-irix$IRIX_REL
+	;;
     ????????:AIX?:[12].1:2)   # AIX 2.2.1 or AIX 2.1.1 is RT/PC AIX.
-	echo romp-ibm-aix     # uname -m gives an 8 hex-code CPU id
-	exit ;;               # Note that: echo "'`uname -s`'" gives 'AIX '
+	GUESS=romp-ibm-aix    # uname -m gives an 8 hex-code CPU id
+	;;                    # Note that: echo "'`uname -s`'" gives 'AIX '
     i*86:AIX:*:*)
-	echo i386-ibm-aix
-	exit ;;
+	GUESS=i386-ibm-aix
+	;;
     ia64:AIX:*:*)
-	if [ -x /usr/bin/oslevel ] ; then
+	if test -x /usr/bin/oslevel ; then
 		IBM_REV=`/usr/bin/oslevel`
 	else
-		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
+		IBM_REV=$UNAME_VERSION.$UNAME_RELEASE
 	fi
-	echo "$UNAME_MACHINE"-ibm-aix"$IBM_REV"
-	exit ;;
+	GUESS=$UNAME_MACHINE-ibm-aix$IBM_REV
+	;;
     *:AIX:2:3)
 	if grep bos325 /usr/include/stdio.h >/dev/null 2>&1; then
 		set_cc_for_build
@@ -603,16 +638,16 @@ EOF
 EOF
 		if $CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"`
 		then
-			echo "$SYSTEM_NAME"
+			GUESS=$SYSTEM_NAME
 		else
-			echo rs6000-ibm-aix3.2.5
+			GUESS=rs6000-ibm-aix3.2.5
 		fi
 	elif grep bos324 /usr/include/stdio.h >/dev/null 2>&1; then
-		echo rs6000-ibm-aix3.2.4
+		GUESS=rs6000-ibm-aix3.2.4
 	else
-		echo rs6000-ibm-aix3.2
+		GUESS=rs6000-ibm-aix3.2
 	fi
-	exit ;;
+	;;
     *:AIX:*:[4567])
 	IBM_CPU_ID=`/usr/sbin/lsdev -C -c processor -S available | sed 1q | awk '{ print $1 }'`
 	if /usr/sbin/lsattr -El "$IBM_CPU_ID" | grep ' POWER' >/dev/null 2>&1; then
@@ -620,56 +655,56 @@ EOF
 	else
 		IBM_ARCH=powerpc
 	fi
-	if [ -x /usr/bin/lslpp ] ; then
-		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
+	if test -x /usr/bin/lslpp ; then
+		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc | \
 			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
 	else
-		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
+		IBM_REV=$UNAME_VERSION.$UNAME_RELEASE
 	fi
-	echo "$IBM_ARCH"-ibm-aix"$IBM_REV"
-	exit ;;
+	GUESS=$IBM_ARCH-ibm-aix$IBM_REV
+	;;
     *:AIX:*:*)
-	echo rs6000-ibm-aix
-	exit ;;
+	GUESS=rs6000-ibm-aix
+	;;
     ibmrt:4.4BSD:*|romp-ibm:4.4BSD:*)
-	echo romp-ibm-bsd4.4
-	exit ;;
+	GUESS=romp-ibm-bsd4.4
+	;;
     ibmrt:*BSD:*|romp-ibm:BSD:*)            # covers RT/PC BSD and
-	echo romp-ibm-bsd"$UNAME_RELEASE"   # 4.3 with uname added to
-	exit ;;                             # report: romp-ibm BSD 4.3
+	GUESS=romp-ibm-bsd$UNAME_RELEASE    # 4.3 with uname added to
+	;;                                  # report: romp-ibm BSD 4.3
     *:BOSX:*:*)
-	echo rs6000-bull-bosx
-	exit ;;
+	GUESS=rs6000-bull-bosx
+	;;
     DPX/2?00:B.O.S.:*:*)
-	echo m68k-bull-sysv3
-	exit ;;
+	GUESS=m68k-bull-sysv3
+	;;
     9000/[34]??:4.3bsd:1.*:*)
-	echo m68k-hp-bsd
-	exit ;;
+	GUESS=m68k-hp-bsd
+	;;
     hp300:4.4BSD:*:* | 9000/[34]??:4.3bsd:2.*:*)
-	echo m68k-hp-bsd4.4
-	exit ;;
+	GUESS=m68k-hp-bsd4.4
+	;;
     9000/[34678]??:HP-UX:*:*)
-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
-	case "$UNAME_MACHINE" in
+	HPUX_REV=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*.[0B]*//'`
+	case $UNAME_MACHINE in
 	    9000/31?)            HP_ARCH=m68000 ;;
 	    9000/[34]??)         HP_ARCH=m68k ;;
 	    9000/[678][0-9][0-9])
-		if [ -x /usr/bin/getconf ]; then
+		if test -x /usr/bin/getconf; then
 		    sc_cpu_version=`/usr/bin/getconf SC_CPU_VERSION 2>/dev/null`
 		    sc_kernel_bits=`/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null`
-		    case "$sc_cpu_version" in
+		    case $sc_cpu_version in
 		      523) HP_ARCH=hppa1.0 ;; # CPU_PA_RISC1_0
 		      528) HP_ARCH=hppa1.1 ;; # CPU_PA_RISC1_1
 		      532)                      # CPU_PA_RISC2_0
-			case "$sc_kernel_bits" in
+			case $sc_kernel_bits in
 			  32) HP_ARCH=hppa2.0n ;;
 			  64) HP_ARCH=hppa2.0w ;;
 			  '') HP_ARCH=hppa2.0 ;;   # HP-UX 10.20
 			esac ;;
 		    esac
 		fi
-		if [ "$HP_ARCH" = "" ]; then
+		if test "$HP_ARCH" = ""; then
 		    set_cc_for_build
 		    sed 's/^		//' << EOF > "$dummy.c"
 
@@ -708,7 +743,7 @@ EOF
 		    test -z "$HP_ARCH" && HP_ARCH=hppa
 		fi ;;
 	esac
-	if [ "$HP_ARCH" = hppa2.0w ]
+	if test "$HP_ARCH" = hppa2.0w
 	then
 	    set_cc_for_build
 
@@ -729,12 +764,12 @@ EOF
 		HP_ARCH=hppa64
 	    fi
 	fi
-	echo "$HP_ARCH"-hp-hpux"$HPUX_REV"
-	exit ;;
+	GUESS=$HP_ARCH-hp-hpux$HPUX_REV
+	;;
     ia64:HP-UX:*:*)
-	HPUX_REV=`echo "$UNAME_RELEASE"|sed -e 's/[^.]*.[0B]*//'`
-	echo ia64-hp-hpux"$HPUX_REV"
-	exit ;;
+	HPUX_REV=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*.[0B]*//'`
+	GUESS=ia64-hp-hpux$HPUX_REV
+	;;
     3050*:HI-UX:*:*)
 	set_cc_for_build
 	sed 's/^	//' << EOF > "$dummy.c"
@@ -764,36 +799,36 @@ EOF
 EOF
 	$CC_FOR_BUILD -o "$dummy" "$dummy.c" && SYSTEM_NAME=`"$dummy"` &&
 		{ echo "$SYSTEM_NAME"; exit; }
-	echo unknown-hitachi-hiuxwe2
-	exit ;;
+	GUESS=unknown-hitachi-hiuxwe2
+	;;
     9000/7??:4.3bsd:*:* | 9000/8?[79]:4.3bsd:*:*)
-	echo hppa1.1-hp-bsd
-	exit ;;
+	GUESS=hppa1.1-hp-bsd
+	;;
     9000/8??:4.3bsd:*:*)
-	echo hppa1.0-hp-bsd
-	exit ;;
+	GUESS=hppa1.0-hp-bsd
+	;;
     *9??*:MPE/iX:*:* | *3000*:MPE/iX:*:*)
-	echo hppa1.0-hp-mpeix
-	exit ;;
+	GUESS=hppa1.0-hp-mpeix
+	;;
     hp7??:OSF1:*:* | hp8?[79]:OSF1:*:*)
-	echo hppa1.1-hp-osf
-	exit ;;
+	GUESS=hppa1.1-hp-osf
+	;;
     hp8??:OSF1:*:*)
-	echo hppa1.0-hp-osf
-	exit ;;
+	GUESS=hppa1.0-hp-osf
+	;;
     i*86:OSF1:*:*)
-	if [ -x /usr/sbin/sysversion ] ; then
-	    echo "$UNAME_MACHINE"-unknown-osf1mk
+	if test -x /usr/sbin/sysversion ; then
+	    GUESS=$UNAME_MACHINE-unknown-osf1mk
 	else
-	    echo "$UNAME_MACHINE"-unknown-osf1
+	    GUESS=$UNAME_MACHINE-unknown-osf1
 	fi
-	exit ;;
+	;;
     parisc*:Lites*:*:*)
-	echo hppa1.1-hp-lites
-	exit ;;
+	GUESS=hppa1.1-hp-lites
+	;;
     C1*:ConvexOS:*:* | convex:ConvexOS:C1*:*)
-	echo c1-convex-bsd
-	exit ;;
+	GUESS=c1-convex-bsd
+	;;
     C2*:ConvexOS:*:* | convex:ConvexOS:C2*:*)
 	if getsysinfo -f scalar_acc
 	then echo c32-convex-bsd
@@ -801,17 +836,18 @@ EOF
 	fi
 	exit ;;
     C34*:ConvexOS:*:* | convex:ConvexOS:C34*:*)
-	echo c34-convex-bsd
-	exit ;;
+	GUESS=c34-convex-bsd
+	;;
     C38*:ConvexOS:*:* | convex:ConvexOS:C38*:*)
-	echo c38-convex-bsd
-	exit ;;
+	GUESS=c38-convex-bsd
+	;;
     C4*:ConvexOS:*:* | convex:ConvexOS:C4*:*)
-	echo c4-convex-bsd
-	exit ;;
+	GUESS=c4-convex-bsd
+	;;
     CRAY*Y-MP:*:*:*)
-	echo ymp-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
-	exit ;;
+	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
+	GUESS=ymp-cray-unicos$CRAY_REL
+	;;
     CRAY*[A-Z]90:*:*:*)
 	echo "$UNAME_MACHINE"-cray-unicos"$UNAME_RELEASE" \
 	| sed -e 's/CRAY.*\([A-Z]90\)/\1/' \
@@ -819,112 +855,133 @@ EOF
 	      -e 's/\.[^.]*$/.X/'
 	exit ;;
     CRAY*TS:*:*:*)
-	echo t90-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
-	exit ;;
+	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
+	GUESS=t90-cray-unicos$CRAY_REL
+	;;
     CRAY*T3E:*:*:*)
-	echo alphaev5-cray-unicosmk"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
-	exit ;;
+	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
+	GUESS=alphaev5-cray-unicosmk$CRAY_REL
+	;;
     CRAY*SV1:*:*:*)
-	echo sv1-cray-unicos"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
-	exit ;;
+	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
+	GUESS=sv1-cray-unicos$CRAY_REL
+	;;
     *:UNICOS/mp:*:*)
-	echo craynv-cray-unicosmp"$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'
-	exit ;;
+	CRAY_REL=`echo "$UNAME_RELEASE" | sed -e 's/\.[^.]*$/.X/'`
+	GUESS=craynv-cray-unicosmp$CRAY_REL
+	;;
     F30[01]:UNIX_System_V:*:* | F700:UNIX_System_V:*:*)
 	FUJITSU_PROC=`uname -m | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz`
 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
 	FUJITSU_REL=`echo "$UNAME_RELEASE" | sed -e 's/ /_/'`
-	echo "${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
-	exit ;;
+	GUESS=${FUJITSU_PROC}-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}
+	;;
     5000:UNIX_System_V:4.*:*)
 	FUJITSU_SYS=`uname -p | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/\///'`
 	FUJITSU_REL=`echo "$UNAME_RELEASE" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz | sed -e 's/ /_/'`
-	echo "sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}"
-	exit ;;
+	GUESS=sparc-fujitsu-${FUJITSU_SYS}${FUJITSU_REL}
+	;;
     i*86:BSD/386:*:* | i*86:BSD/OS:*:* | *:Ascend\ Embedded/OS:*:*)
-	echo "$UNAME_MACHINE"-pc-bsdi"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-bsdi$UNAME_RELEASE
+	;;
     sparc*:BSD/OS:*:*)
-	echo sparc-unknown-bsdi"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sparc-unknown-bsdi$UNAME_RELEASE
+	;;
     *:BSD/OS:*:*)
-	echo "$UNAME_MACHINE"-unknown-bsdi"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-bsdi$UNAME_RELEASE
+	;;
     arm:FreeBSD:*:*)
 	UNAME_PROCESSOR=`uname -p`
 	set_cc_for_build
 	if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
 	    | grep -q __ARM_PCS_VFP
 	then
-	    echo "${UNAME_PROCESSOR}"-unknown-freebsd"`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`"-gnueabi
+	    FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+	    GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL-gnueabi
 	else
-	    echo "${UNAME_PROCESSOR}"-unknown-freebsd"`echo ${UNAME_RELEASE}|sed -e 's/[-(].*//'`"-gnueabihf
+	    FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+	    GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL-gnueabihf
 	fi
-	exit ;;
+	;;
     *:FreeBSD:*:*)
 	UNAME_PROCESSOR=`/usr/bin/uname -p`
-	case "$UNAME_PROCESSOR" in
+	case $UNAME_PROCESSOR in
 	    amd64)
 		UNAME_PROCESSOR=x86_64 ;;
 	    i386)
 		UNAME_PROCESSOR=i586 ;;
 	esac
-	echo "$UNAME_PROCESSOR"-unknown-freebsd"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
-	exit ;;
+	FREEBSD_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+	GUESS=$UNAME_PROCESSOR-unknown-freebsd$FREEBSD_REL
+	;;
     i*:CYGWIN*:*)
-	echo "$UNAME_MACHINE"-pc-cygwin
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-cygwin
+	;;
     *:MINGW64*:*)
-	echo "$UNAME_MACHINE"-pc-mingw64
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-mingw64
+	;;
     *:MINGW*:*)
-	echo "$UNAME_MACHINE"-pc-mingw32
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-mingw32
+	;;
     *:MSYS*:*)
-	echo "$UNAME_MACHINE"-pc-msys
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-msys
+	;;
     i*:PW*:*)
-	echo "$UNAME_MACHINE"-pc-pw32
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-pw32
+	;;
+    *:SerenityOS:*:*)
+        GUESS=$UNAME_MACHINE-pc-serenity
+        ;;
     *:Interix*:*)
-	case "$UNAME_MACHINE" in
+	case $UNAME_MACHINE in
 	    x86)
-		echo i586-pc-interix"$UNAME_RELEASE"
-		exit ;;
+		GUESS=i586-pc-interix$UNAME_RELEASE
+		;;
 	    authenticamd | genuineintel | EM64T)
-		echo x86_64-unknown-interix"$UNAME_RELEASE"
-		exit ;;
+		GUESS=x86_64-unknown-interix$UNAME_RELEASE
+		;;
 	    IA64)
-		echo ia64-unknown-interix"$UNAME_RELEASE"
-		exit ;;
+		GUESS=ia64-unknown-interix$UNAME_RELEASE
+		;;
 	esac ;;
     i*:UWIN*:*)
-	echo "$UNAME_MACHINE"-pc-uwin
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-uwin
+	;;
     amd64:CYGWIN*:*:* | x86_64:CYGWIN*:*:*)
-	echo x86_64-pc-cygwin
-	exit ;;
+	GUESS=x86_64-pc-cygwin
+	;;
     prep*:SunOS:5.*:*)
-	echo powerpcle-unknown-solaris2"`echo "$UNAME_RELEASE"|sed -e 's/[^.]*//'`"
-	exit ;;
+	SUN_REL=`echo "$UNAME_RELEASE" | sed -e 's/[^.]*//'`
+	GUESS=powerpcle-unknown-solaris2$SUN_REL
+	;;
     *:GNU:*:*)
 	# the GNU system
-	echo "`echo "$UNAME_MACHINE"|sed -e 's,[-/].*$,,'`-unknown-$LIBC`echo "$UNAME_RELEASE"|sed -e 's,/.*$,,'`"
-	exit ;;
+	GNU_ARCH=`echo "$UNAME_MACHINE" | sed -e 's,[-/].*$,,'`
+	GNU_REL=`echo "$UNAME_RELEASE" | sed -e 's,/.*$,,'`
+	GUESS=$GNU_ARCH-unknown-$LIBC$GNU_REL
+	;;
     *:GNU/*:*:*)
 	# other systems with GNU libc and userland
-	echo "$UNAME_MACHINE-unknown-`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"``echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`-$LIBC"
-	exit ;;
+	GNU_SYS=`echo "$UNAME_SYSTEM" | sed 's,^[^/]*/,,' | tr "[:upper:]" "[:lower:]"`
+	GNU_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+	GUESS=$UNAME_MACHINE-unknown-$GNU_SYS$GNU_REL-$LIBC
+	;;
+    x86_64:[Mm]anagarm:*:*|i?86:[Mm]anagarm:*:*)
+	GUESS="$UNAME_MACHINE-pc-managarm-mlibc"
+	;;
+    *:[Mm]anagarm:*:*)
+	GUESS="$UNAME_MACHINE-unknown-managarm-mlibc"
+	;;
     *:Minix:*:*)
-	echo "$UNAME_MACHINE"-unknown-minix
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-minix
+	;;
     aarch64:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     aarch64_be:Linux:*:*)
 	UNAME_MACHINE=aarch64_be
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     alpha:Linux:*:*)
 	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' /proc/cpuinfo 2>/dev/null` in
 	  EV5)   UNAME_MACHINE=alphaev5 ;;
@@ -937,60 +994,63 @@ EOF
 	esac
 	objdump --private-headers /bin/sh | grep -q ld.so.1
 	if test "$?" = 0 ; then LIBC=gnulibc1 ; fi
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
-    arc:Linux:*:* | arceb:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
+    arc:Linux:*:* | arceb:Linux:*:* | arc32:Linux:*:* | arc64:Linux:*:*)
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     arm*:Linux:*:*)
 	set_cc_for_build
 	if echo __ARM_EABI__ | $CC_FOR_BUILD -E - 2>/dev/null \
 	    | grep -q __ARM_EABI__
 	then
-	    echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+	    GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
 	else
 	    if echo __ARM_PCS_VFP | $CC_FOR_BUILD -E - 2>/dev/null \
 		| grep -q __ARM_PCS_VFP
 	    then
-		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabi
+		GUESS=$UNAME_MACHINE-unknown-linux-${LIBC}eabi
 	    else
-		echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"eabihf
+		GUESS=$UNAME_MACHINE-unknown-linux-${LIBC}eabihf
 	    fi
 	fi
-	exit ;;
+	;;
     avr32*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     cris:Linux:*:*)
-	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-axis-linux-$LIBC
+	;;
     crisv32:Linux:*:*)
-	echo "$UNAME_MACHINE"-axis-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-axis-linux-$LIBC
+	;;
     e2k:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     frv:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     hexagon:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     i*86:Linux:*:*)
-	echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-linux-$LIBC
+	;;
     ia64:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     k1om:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
+    loongarch32:Linux:*:* | loongarch64:Linux:*:*)
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     m32r*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     m68*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     mips:Linux:*:* | mips64:Linux:*:*)
 	set_cc_for_build
 	IS_GLIBC=0
@@ -1035,123 +1095,135 @@ EOF
 	#endif
 	#endif
 EOF
-	eval "`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU\|^MIPS_ENDIAN\|^LIBCABI'`"
+	cc_set_vars=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^CPU\|^MIPS_ENDIAN\|^LIBCABI'`
+	eval "$cc_set_vars"
 	test "x$CPU" != x && { echo "$CPU${MIPS_ENDIAN}-unknown-linux-$LIBCABI"; exit; }
 	;;
     mips64el:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     openrisc*:Linux:*:*)
-	echo or1k-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=or1k-unknown-linux-$LIBC
+	;;
     or32:Linux:*:* | or1k*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     padre:Linux:*:*)
-	echo sparc-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=sparc-unknown-linux-$LIBC
+	;;
     parisc64:Linux:*:* | hppa64:Linux:*:*)
-	echo hppa64-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=hppa64-unknown-linux-$LIBC
+	;;
     parisc:Linux:*:* | hppa:Linux:*:*)
 	# Look for CPU level
 	case `grep '^cpu[^a-z]*:' /proc/cpuinfo 2>/dev/null | cut -d' ' -f2` in
-	  PA7*) echo hppa1.1-unknown-linux-"$LIBC" ;;
-	  PA8*) echo hppa2.0-unknown-linux-"$LIBC" ;;
-	  *)    echo hppa-unknown-linux-"$LIBC" ;;
+	  PA7*) GUESS=hppa1.1-unknown-linux-$LIBC ;;
+	  PA8*) GUESS=hppa2.0-unknown-linux-$LIBC ;;
+	  *)    GUESS=hppa-unknown-linux-$LIBC ;;
 	esac
-	exit ;;
+	;;
     ppc64:Linux:*:*)
-	echo powerpc64-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=powerpc64-unknown-linux-$LIBC
+	;;
     ppc:Linux:*:*)
-	echo powerpc-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=powerpc-unknown-linux-$LIBC
+	;;
     ppc64le:Linux:*:*)
-	echo powerpc64le-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=powerpc64le-unknown-linux-$LIBC
+	;;
     ppcle:Linux:*:*)
-	echo powerpcle-unknown-linux-"$LIBC"
-	exit ;;
-    riscv32:Linux:*:* | riscv64:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=powerpcle-unknown-linux-$LIBC
+	;;
+    riscv32:Linux:*:* | riscv32be:Linux:*:* | riscv64:Linux:*:* | riscv64be:Linux:*:*)
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     s390:Linux:*:* | s390x:Linux:*:*)
-	echo "$UNAME_MACHINE"-ibm-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-ibm-linux-$LIBC
+	;;
     sh64*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     sh*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     sparc:Linux:*:* | sparc64:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     tile*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     vax:Linux:*:*)
-	echo "$UNAME_MACHINE"-dec-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-dec-linux-$LIBC
+	;;
     x86_64:Linux:*:*)
 	set_cc_for_build
+	CPU=$UNAME_MACHINE
 	LIBCABI=$LIBC
-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
-	    if (echo '#ifdef __ILP32__'; echo IS_X32; echo '#endif') | \
-		(CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
-		grep IS_X32 >/dev/null
-	    then
-		LIBCABI="$LIBC"x32
-	    fi
+	if test "$CC_FOR_BUILD" != no_compiler_found; then
+	    ABI=64
+	    sed 's/^	    //' << EOF > "$dummy.c"
+	    #ifdef __i386__
+	    ABI=x86
+	    #else
+	    #ifdef __ILP32__
+	    ABI=x32
+	    #endif
+	    #endif
+EOF
+	    cc_set_abi=`$CC_FOR_BUILD -E "$dummy.c" 2>/dev/null | grep '^ABI' | sed 's, ,,g'`
+	    eval "$cc_set_abi"
+	    case $ABI in
+		x86) CPU=i686 ;;
+		x32) LIBCABI=${LIBC}x32 ;;
+	    esac
 	fi
-	echo "$UNAME_MACHINE"-pc-linux-"$LIBCABI"
-	exit ;;
+	GUESS=$CPU-pc-linux-$LIBCABI
+	;;
     xtensa*:Linux:*:*)
-	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-linux-$LIBC
+	;;
     i*86:DYNIX/ptx:4*:*)
 	# ptx 4.0 does uname -s correctly, with DYNIX/ptx in there.
 	# earlier versions are messed up and put the nodename in both
 	# sysname and nodename.
-	echo i386-sequent-sysv4
-	exit ;;
+	GUESS=i386-sequent-sysv4
+	;;
     i*86:UNIX_SV:4.2MP:2.*)
 	# Unixware is an offshoot of SVR4, but it has its own version
 	# number series starting with 2...
 	# I am not positive that other SVR4 systems won't match this,
 	# I just have to hope.  -- rms.
 	# Use sysv4.2uw... so that sysv4* matches it.
-	echo "$UNAME_MACHINE"-pc-sysv4.2uw"$UNAME_VERSION"
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-sysv4.2uw$UNAME_VERSION
+	;;
     i*86:OS/2:*:*)
 	# If we were able to find `uname', then EMX Unix compatibility
 	# is probably installed.
-	echo "$UNAME_MACHINE"-pc-os2-emx
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-os2-emx
+	;;
     i*86:XTS-300:*:STOP)
-	echo "$UNAME_MACHINE"-unknown-stop
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-stop
+	;;
     i*86:atheos:*:*)
-	echo "$UNAME_MACHINE"-unknown-atheos
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-atheos
+	;;
     i*86:syllable:*:*)
-	echo "$UNAME_MACHINE"-pc-syllable
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-syllable
+	;;
     i*86:LynxOS:2.*:* | i*86:LynxOS:3.[01]*:* | i*86:LynxOS:4.[02]*:*)
-	echo i386-unknown-lynxos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=i386-unknown-lynxos$UNAME_RELEASE
+	;;
     i*86:*DOS:*:*)
-	echo "$UNAME_MACHINE"-pc-msdosdjgpp
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-msdosdjgpp
+	;;
     i*86:*:4.*:*)
 	UNAME_REL=`echo "$UNAME_RELEASE" | sed 's/\/MP$//'`
 	if grep Novell /usr/include/link.h >/dev/null 2>/dev/null; then
-		echo "$UNAME_MACHINE"-univel-sysv"$UNAME_REL"
+		GUESS=$UNAME_MACHINE-univel-sysv$UNAME_REL
 	else
-		echo "$UNAME_MACHINE"-pc-sysv"$UNAME_REL"
+		GUESS=$UNAME_MACHINE-pc-sysv$UNAME_REL
 	fi
-	exit ;;
+	;;
     i*86:*:5:[678]*)
 	# UnixWare 7.x, OpenUNIX and OpenServer 6.
 	case `/bin/uname -X | grep "^Machine"` in
@@ -1159,12 +1231,12 @@ EOF
 	    *Pentium)	     UNAME_MACHINE=i586 ;;
 	    *Pent*|*Celeron) UNAME_MACHINE=i686 ;;
 	esac
-	echo "$UNAME_MACHINE-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}${UNAME_VERSION}"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-sysv${UNAME_RELEASE}${UNAME_SYSTEM}${UNAME_VERSION}
+	;;
     i*86:*:3.2:*)
 	if test -f /usr/options/cb.name; then
 		UNAME_REL=`sed -n 's/.*Version //p' </usr/options/cb.name`
-		echo "$UNAME_MACHINE"-pc-isc"$UNAME_REL"
+		GUESS=$UNAME_MACHINE-pc-isc$UNAME_REL
 	elif /bin/uname -X 2>/dev/null >/dev/null ; then
 		UNAME_REL=`(/bin/uname -X|grep Release|sed -e 's/.*= //')`
 		(/bin/uname -X|grep i80486 >/dev/null) && UNAME_MACHINE=i486
@@ -1174,11 +1246,11 @@ EOF
 			&& UNAME_MACHINE=i686
 		(/bin/uname -X|grep '^Machine.*Pentium Pro' >/dev/null) \
 			&& UNAME_MACHINE=i686
-		echo "$UNAME_MACHINE"-pc-sco"$UNAME_REL"
+		GUESS=$UNAME_MACHINE-pc-sco$UNAME_REL
 	else
-		echo "$UNAME_MACHINE"-pc-sysv32
+		GUESS=$UNAME_MACHINE-pc-sysv32
 	fi
-	exit ;;
+	;;
     pc:*:*:*)
 	# Left here for compatibility:
 	# uname -m prints for DJGPP always 'pc', but it prints nothing about
@@ -1186,31 +1258,31 @@ EOF
 	# Note: whatever this is, it MUST be the same as what config.sub
 	# prints for the "djgpp" host, or else GDB configure will decide that
 	# this is a cross-build.
-	echo i586-pc-msdosdjgpp
-	exit ;;
+	GUESS=i586-pc-msdosdjgpp
+	;;
     Intel:Mach:3*:*)
-	echo i386-pc-mach3
-	exit ;;
+	GUESS=i386-pc-mach3
+	;;
     paragon:*:*:*)
-	echo i860-intel-osf1
-	exit ;;
+	GUESS=i860-intel-osf1
+	;;
     i860:*:4.*:*) # i860-SVR4
 	if grep Stardent /usr/include/sys/uadmin.h >/dev/null 2>&1 ; then
-	  echo i860-stardent-sysv"$UNAME_RELEASE" # Stardent Vistra i860-SVR4
+	  GUESS=i860-stardent-sysv$UNAME_RELEASE    # Stardent Vistra i860-SVR4
 	else # Add other i860-SVR4 vendors below as they are discovered.
-	  echo i860-unknown-sysv"$UNAME_RELEASE"  # Unknown i860-SVR4
+	  GUESS=i860-unknown-sysv$UNAME_RELEASE     # Unknown i860-SVR4
 	fi
-	exit ;;
+	;;
     mini*:CTIX:SYS*5:*)
 	# "miniframe"
-	echo m68010-convergent-sysv
-	exit ;;
+	GUESS=m68010-convergent-sysv
+	;;
     mc68k:UNIX:SYSTEM5:3.51m)
-	echo m68k-convergent-sysv
-	exit ;;
+	GUESS=m68k-convergent-sysv
+	;;
     M680?0:D-NIX:5.3:*)
-	echo m68k-diab-dnix
-	exit ;;
+	GUESS=m68k-diab-dnix
+	;;
     M68*:*:R3V[5678]*:*)
 	test -r /sysV68 && { echo 'm68k-motorola-sysv'; exit; } ;;
     3[345]??:*:4.0:3.0 | 3[34]??A:*:4.0:3.0 | 3[34]??,*:*:4.0:3.0 | 3[34]??/*:*:4.0:3.0 | 4400:*:4.0:3.0 | 4850:*:4.0:3.0 | SKA40:*:4.0:3.0 | SDS2:*:4.0:3.0 | SHG2:*:4.0:3.0 | S7501*:*:4.0:3.0)
@@ -1235,116 +1307,119 @@ EOF
 	/bin/uname -p 2>/dev/null | /bin/grep pteron >/dev/null \
 	    && { echo i586-ncr-sysv4.3"$OS_REL"; exit; } ;;
     m68*:LynxOS:2.*:* | m68*:LynxOS:3.0*:*)
-	echo m68k-unknown-lynxos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-unknown-lynxos$UNAME_RELEASE
+	;;
     mc68030:UNIX_System_V:4.*:*)
-	echo m68k-atari-sysv4
-	exit ;;
+	GUESS=m68k-atari-sysv4
+	;;
     TSUNAMI:LynxOS:2.*:*)
-	echo sparc-unknown-lynxos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sparc-unknown-lynxos$UNAME_RELEASE
+	;;
     rs6000:LynxOS:2.*:*)
-	echo rs6000-unknown-lynxos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=rs6000-unknown-lynxos$UNAME_RELEASE
+	;;
     PowerPC:LynxOS:2.*:* | PowerPC:LynxOS:3.[01]*:* | PowerPC:LynxOS:4.[02]*:*)
-	echo powerpc-unknown-lynxos"$UNAME_RELEASE"
-	exit ;;
+	GUESS=powerpc-unknown-lynxos$UNAME_RELEASE
+	;;
     SM[BE]S:UNIX_SV:*:*)
-	echo mips-dde-sysv"$UNAME_RELEASE"
-	exit ;;
+	GUESS=mips-dde-sysv$UNAME_RELEASE
+	;;
     RM*:ReliantUNIX-*:*:*)
-	echo mips-sni-sysv4
-	exit ;;
+	GUESS=mips-sni-sysv4
+	;;
     RM*:SINIX-*:*:*)
-	echo mips-sni-sysv4
-	exit ;;
+	GUESS=mips-sni-sysv4
+	;;
     *:SINIX-*:*:*)
 	if uname -p 2>/dev/null >/dev/null ; then
 		UNAME_MACHINE=`(uname -p) 2>/dev/null`
-		echo "$UNAME_MACHINE"-sni-sysv4
+		GUESS=$UNAME_MACHINE-sni-sysv4
 	else
-		echo ns32k-sni-sysv
+		GUESS=ns32k-sni-sysv
 	fi
-	exit ;;
+	;;
     PENTIUM:*:4.0*:*)	# Unisys `ClearPath HMP IX 4000' SVR4/MP effort
 			# says <Richard.M.Bartel@ccMail.Census.GOV>
-	echo i586-unisys-sysv4
-	exit ;;
+	GUESS=i586-unisys-sysv4
+	;;
     *:UNIX_System_V:4*:FTX*)
 	# From Gerald Hewes <hewes@openmarket.com>.
 	# How about differentiating between stratus architectures? -djm
-	echo hppa1.1-stratus-sysv4
-	exit ;;
+	GUESS=hppa1.1-stratus-sysv4
+	;;
     *:*:*:FTX*)
 	# From seanf@swdc.stratus.com.
-	echo i860-stratus-sysv4
-	exit ;;
+	GUESS=i860-stratus-sysv4
+	;;
     i*86:VOS:*:*)
 	# From Paul.Green@stratus.com.
-	echo "$UNAME_MACHINE"-stratus-vos
-	exit ;;
+	GUESS=$UNAME_MACHINE-stratus-vos
+	;;
     *:VOS:*:*)
 	# From Paul.Green@stratus.com.
-	echo hppa1.1-stratus-vos
-	exit ;;
+	GUESS=hppa1.1-stratus-vos
+	;;
     mc68*:A/UX:*:*)
-	echo m68k-apple-aux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=m68k-apple-aux$UNAME_RELEASE
+	;;
     news*:NEWS-OS:6*:*)
-	echo mips-sony-newsos6
-	exit ;;
+	GUESS=mips-sony-newsos6
+	;;
     R[34]000:*System_V*:*:* | R4000:UNIX_SYSV:*:* | R*000:UNIX_SV:*:*)
-	if [ -d /usr/nec ]; then
-		echo mips-nec-sysv"$UNAME_RELEASE"
+	if test -d /usr/nec; then
+		GUESS=mips-nec-sysv$UNAME_RELEASE
 	else
-		echo mips-unknown-sysv"$UNAME_RELEASE"
+		GUESS=mips-unknown-sysv$UNAME_RELEASE
 	fi
-	exit ;;
+	;;
     BeBox:BeOS:*:*)	# BeOS running on hardware made by Be, PPC only.
-	echo powerpc-be-beos
-	exit ;;
+	GUESS=powerpc-be-beos
+	;;
     BeMac:BeOS:*:*)	# BeOS running on Mac or Mac clone, PPC only.
-	echo powerpc-apple-beos
-	exit ;;
+	GUESS=powerpc-apple-beos
+	;;
     BePC:BeOS:*:*)	# BeOS running on Intel PC compatible.
-	echo i586-pc-beos
-	exit ;;
+	GUESS=i586-pc-beos
+	;;
     BePC:Haiku:*:*)	# Haiku running on Intel PC compatible.
-	echo i586-pc-haiku
-	exit ;;
-    x86_64:Haiku:*:*)
-	echo x86_64-unknown-haiku
-	exit ;;
+	GUESS=i586-pc-haiku
+	;;
+    ppc:Haiku:*:*)	# Haiku running on Apple PowerPC
+	GUESS=powerpc-apple-haiku
+	;;
+    *:Haiku:*:*)	# Haiku modern gcc (not bound by BeOS compat)
+	GUESS=$UNAME_MACHINE-unknown-haiku
+	;;
     SX-4:SUPER-UX:*:*)
-	echo sx4-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx4-nec-superux$UNAME_RELEASE
+	;;
     SX-5:SUPER-UX:*:*)
-	echo sx5-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx5-nec-superux$UNAME_RELEASE
+	;;
     SX-6:SUPER-UX:*:*)
-	echo sx6-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx6-nec-superux$UNAME_RELEASE
+	;;
     SX-7:SUPER-UX:*:*)
-	echo sx7-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx7-nec-superux$UNAME_RELEASE
+	;;
     SX-8:SUPER-UX:*:*)
-	echo sx8-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx8-nec-superux$UNAME_RELEASE
+	;;
     SX-8R:SUPER-UX:*:*)
-	echo sx8r-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sx8r-nec-superux$UNAME_RELEASE
+	;;
     SX-ACE:SUPER-UX:*:*)
-	echo sxace-nec-superux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=sxace-nec-superux$UNAME_RELEASE
+	;;
     Power*:Rhapsody:*:*)
-	echo powerpc-apple-rhapsody"$UNAME_RELEASE"
-	exit ;;
+	GUESS=powerpc-apple-rhapsody$UNAME_RELEASE
+	;;
     *:Rhapsody:*:*)
-	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-apple-rhapsody$UNAME_RELEASE
+	;;
     arm64:Darwin:*:*)
-	echo aarch64-apple-darwin"$UNAME_RELEASE"
-	exit ;;
+	GUESS=aarch64-apple-darwin$UNAME_RELEASE
+	;;
     *:Darwin:*:*)
 	UNAME_PROCESSOR=`uname -p`
 	case $UNAME_PROCESSOR in
@@ -1359,7 +1434,7 @@ EOF
 	else
 	    set_cc_for_build
 	fi
-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
+	if test "$CC_FOR_BUILD" != no_compiler_found; then
 	    if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
 		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
 		   grep IS_64BIT_ARCH >/dev/null
@@ -1380,108 +1455,118 @@ EOF
 	    # uname -m returns i386 or x86_64
 	    UNAME_PROCESSOR=$UNAME_MACHINE
 	fi
-	echo "$UNAME_PROCESSOR"-apple-darwin"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_PROCESSOR-apple-darwin$UNAME_RELEASE
+	;;
     *:procnto*:*:* | *:QNX:[0123456789]*:*)
 	UNAME_PROCESSOR=`uname -p`
 	if test "$UNAME_PROCESSOR" = x86; then
 		UNAME_PROCESSOR=i386
 		UNAME_MACHINE=pc
 	fi
-	echo "$UNAME_PROCESSOR"-"$UNAME_MACHINE"-nto-qnx"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_PROCESSOR-$UNAME_MACHINE-nto-qnx$UNAME_RELEASE
+	;;
     *:QNX:*:4*)
-	echo i386-pc-qnx
-	exit ;;
+	GUESS=i386-pc-qnx
+	;;
     NEO-*:NONSTOP_KERNEL:*:*)
-	echo neo-tandem-nsk"$UNAME_RELEASE"
-	exit ;;
+	GUESS=neo-tandem-nsk$UNAME_RELEASE
+	;;
     NSE-*:NONSTOP_KERNEL:*:*)
-	echo nse-tandem-nsk"$UNAME_RELEASE"
-	exit ;;
+	GUESS=nse-tandem-nsk$UNAME_RELEASE
+	;;
     NSR-*:NONSTOP_KERNEL:*:*)
-	echo nsr-tandem-nsk"$UNAME_RELEASE"
-	exit ;;
+	GUESS=nsr-tandem-nsk$UNAME_RELEASE
+	;;
     NSV-*:NONSTOP_KERNEL:*:*)
-	echo nsv-tandem-nsk"$UNAME_RELEASE"
-	exit ;;
+	GUESS=nsv-tandem-nsk$UNAME_RELEASE
+	;;
     NSX-*:NONSTOP_KERNEL:*:*)
-	echo nsx-tandem-nsk"$UNAME_RELEASE"
-	exit ;;
+	GUESS=nsx-tandem-nsk$UNAME_RELEASE
+	;;
     *:NonStop-UX:*:*)
-	echo mips-compaq-nonstopux
-	exit ;;
+	GUESS=mips-compaq-nonstopux
+	;;
     BS2000:POSIX*:*:*)
-	echo bs2000-siemens-sysv
-	exit ;;
+	GUESS=bs2000-siemens-sysv
+	;;
     DS/*:UNIX_System_V:*:*)
-	echo "$UNAME_MACHINE"-"$UNAME_SYSTEM"-"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-$UNAME_SYSTEM-$UNAME_RELEASE
+	;;
     *:Plan9:*:*)
 	# "uname -m" is not consistent, so use $cputype instead. 386
 	# is converted to i386 for consistency with other x86
 	# operating systems.
-	# shellcheck disable=SC2154
-	if test "$cputype" = 386; then
+	if test "${cputype-}" = 386; then
 	    UNAME_MACHINE=i386
-	else
-	    UNAME_MACHINE="$cputype"
+	elif test "x${cputype-}" != x; then
+	    UNAME_MACHINE=$cputype
 	fi
-	echo "$UNAME_MACHINE"-unknown-plan9
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-plan9
+	;;
     *:TOPS-10:*:*)
-	echo pdp10-unknown-tops10
-	exit ;;
+	GUESS=pdp10-unknown-tops10
+	;;
     *:TENEX:*:*)
-	echo pdp10-unknown-tenex
-	exit ;;
+	GUESS=pdp10-unknown-tenex
+	;;
     KS10:TOPS-20:*:* | KL10:TOPS-20:*:* | TYPE4:TOPS-20:*:*)
-	echo pdp10-dec-tops20
-	exit ;;
+	GUESS=pdp10-dec-tops20
+	;;
     XKL-1:TOPS-20:*:* | TYPE5:TOPS-20:*:*)
-	echo pdp10-xkl-tops20
-	exit ;;
+	GUESS=pdp10-xkl-tops20
+	;;
     *:TOPS-20:*:*)
-	echo pdp10-unknown-tops20
-	exit ;;
+	GUESS=pdp10-unknown-tops20
+	;;
     *:ITS:*:*)
-	echo pdp10-unknown-its
-	exit ;;
+	GUESS=pdp10-unknown-its
+	;;
     SEI:*:*:SEIUX)
-	echo mips-sei-seiux"$UNAME_RELEASE"
-	exit ;;
+	GUESS=mips-sei-seiux$UNAME_RELEASE
+	;;
     *:DragonFly:*:*)
-	echo "$UNAME_MACHINE"-unknown-dragonfly"`echo "$UNAME_RELEASE"|sed -e 's/[-(].*//'`"
-	exit ;;
+	DRAGONFLY_REL=`echo "$UNAME_RELEASE" | sed -e 's/[-(].*//'`
+	GUESS=$UNAME_MACHINE-unknown-dragonfly$DRAGONFLY_REL
+	;;
     *:*VMS:*:*)
 	UNAME_MACHINE=`(uname -p) 2>/dev/null`
-	case "$UNAME_MACHINE" in
-	    A*) echo alpha-dec-vms ; exit ;;
-	    I*) echo ia64-dec-vms ; exit ;;
-	    V*) echo vax-dec-vms ; exit ;;
+	case $UNAME_MACHINE in
+	    A*) GUESS=alpha-dec-vms ;;
+	    I*) GUESS=ia64-dec-vms ;;
+	    V*) GUESS=vax-dec-vms ;;
 	esac ;;
     *:XENIX:*:SysV)
-	echo i386-pc-xenix
-	exit ;;
+	GUESS=i386-pc-xenix
+	;;
     i*86:skyos:*:*)
-	echo "$UNAME_MACHINE"-pc-skyos"`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`"
-	exit ;;
+	SKYOS_REL=`echo "$UNAME_RELEASE" | sed -e 's/ .*$//'`
+	GUESS=$UNAME_MACHINE-pc-skyos$SKYOS_REL
+	;;
     i*86:rdos:*:*)
-	echo "$UNAME_MACHINE"-pc-rdos
-	exit ;;
-    i*86:AROS:*:*)
-	echo "$UNAME_MACHINE"-pc-aros
-	exit ;;
+	GUESS=$UNAME_MACHINE-pc-rdos
+	;;
+    i*86:Fiwix:*:*)
+	GUESS=$UNAME_MACHINE-pc-fiwix
+	;;
+    *:AROS:*:*)
+	GUESS=$UNAME_MACHINE-unknown-aros
+	;;
     x86_64:VMkernel:*:*)
-	echo "$UNAME_MACHINE"-unknown-esx
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-esx
+	;;
     amd64:Isilon\ OneFS:*:*)
-	echo x86_64-unknown-onefs
-	exit ;;
+	GUESS=x86_64-unknown-onefs
+	;;
     *:Unleashed:*:*)
-	echo "$UNAME_MACHINE"-unknown-unleashed"$UNAME_RELEASE"
-	exit ;;
+	GUESS=$UNAME_MACHINE-unknown-unleashed$UNAME_RELEASE
+	;;
 esac
+
+# Do we have a guess based on uname results?
+if test "x$GUESS" != x; then
+    echo "$GUESS"
+    exit
+fi
 
 # No uname command or uname output not recognized.
 set_cc_for_build
@@ -1614,7 +1699,7 @@ main ()
 }
 EOF
 
-$CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null && SYSTEM_NAME=`$dummy` &&
+$CC_FOR_BUILD -o "$dummy" "$dummy.c" 2>/dev/null && SYSTEM_NAME=`"$dummy"` &&
 	{ echo "$SYSTEM_NAME"; exit; }
 
 # Apollos put the system type in the environment.
@@ -1622,7 +1707,7 @@ test -d /usr/apollo && { echo "$ISP-apollo-$SYSTYPE"; exit; }
 
 echo "$0: unable to guess system type" >&2
 
-case "$UNAME_MACHINE:$UNAME_SYSTEM" in
+case $UNAME_MACHINE:$UNAME_SYSTEM in
     mips:Linux | mips64:Linux)
 	# If we got here on MIPS GNU/Linux, output extra information.
 	cat >&2 <<EOF
@@ -1639,14 +1724,16 @@ This script (version $timestamp), has failed to recognize the
 operating system you are using. If your script is old, overwrite *all*
 copies of config.guess and config.sub with the latest versions from:
 
-  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess
+  https://git.savannah.gnu.org/cgit/config.git/plain/config.guess
 and
-  https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub
+  https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
 EOF
 
-year=`echo $timestamp | sed 's,-.*,,'`
+our_year=`echo $timestamp | sed 's,-.*,,'`
+thisyear=`date +%Y`
 # shellcheck disable=SC2003
-if test "`expr "\`date +%Y\`" - "$year"`" -lt 3 ; then
+script_age=`expr "$thisyear" - "$our_year"`
+if test "$script_age" -lt 3 ; then
    cat >&2 <<EOF
 
 If $0 has already been updated, send the following data and any

--- a/build-aux/config.sub
+++ b/build-aux/config.sub
@@ -1,12 +1,14 @@
 #! /bin/sh
 # Configuration validation subroutine script.
-#   Copyright 1992-2020 Free Software Foundation, Inc.
+#   Copyright 1992-2022 Free Software Foundation, Inc.
 
-timestamp='2020-07-10'
+# shellcheck disable=SC2006,SC2268 # see below for rationale
+
+timestamp='2022-09-17'
 
 # This file is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
+# the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
 # This program is distributed in the hope that it will be useful, but
@@ -33,7 +35,7 @@ timestamp='2020-07-10'
 # Otherwise, we print the canonical config type on stdout and succeed.
 
 # You can get the latest version of this script from:
-# https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub
+# https://git.savannah.gnu.org/cgit/config.git/plain/config.sub
 
 # This file is supposed to be the same for all GNU packages
 # and recognize all the CPU types, system types and aliases
@@ -49,6 +51,13 @@ timestamp='2020-07-10'
 # or in some cases, the newer four-part form:
 #	CPU_TYPE-MANUFACTURER-KERNEL-OPERATING_SYSTEM
 # It is wrong to echo any other type of specification.
+
+# The "shellcheck disable" line above the timestamp inhibits complaints
+# about features and limitations of the classic Bourne shell that were
+# superseded or lifted in POSIX.  However, this script identifies a wide
+# variety of pre-POSIX systems that do not have POSIX shells at all, and
+# even some reasonably current systems (Solaris 10 as case-in-point) still
+# have a pre-POSIX /bin/sh.
 
 me=`echo "$0" | sed -e 's,.*/,,'`
 
@@ -67,7 +76,7 @@ Report bugs and patches to <config-patches@gnu.org>."
 version="\
 GNU config.sub ($timestamp)
 
-Copyright 1992-2020 Free Software Foundation, Inc.
+Copyright 1992-2022 Free Software Foundation, Inc.
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
@@ -112,9 +121,11 @@ esac
 
 # Split fields of configuration type
 # shellcheck disable=SC2162
+saved_IFS=$IFS
 IFS="-" read field1 field2 field3 field4 <<EOF
 $1
 EOF
+IFS=$saved_IFS
 
 # Separate into logical components for further validation
 case $1 in
@@ -134,7 +145,7 @@ case $1 in
 			nto-qnx* | linux-* | uclinux-uclibc* \
 			| uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* \
 			| netbsd*-eabi* | kopensolaris*-gnu* | cloudabi*-eabi* \
-			| storm-chaos* | os2-emx* | rtmk-nova*)
+			| storm-chaos* | os2-emx* | rtmk-nova* | managarm-*)
 				basic_machine=$field1
 				basic_os=$maybe_os
 				;;
@@ -161,6 +172,10 @@ case $1 in
 					# Prevent following clause from handling this valid os
 					sun*os*)
 						basic_machine=$field1
+						basic_os=$field2
+						;;
+					zephyr*)
+						basic_machine=$field1-unknown
 						basic_os=$field2
 						;;
 					# Manufacturers
@@ -922,9 +937,11 @@ case $basic_machine in
 
 	*-*)
 		# shellcheck disable=SC2162
+		saved_IFS=$IFS
 		IFS="-" read cpu vendor <<EOF
 $basic_machine
 EOF
+		IFS=$saved_IFS
 		;;
 	# We use `pc' rather than `unknown'
 	# because (1) that's what they normally are, and
@@ -1003,6 +1020,11 @@ case $cpu-$vendor in
 		;;
 
 	# Here we normalize CPU types with a missing or matching vendor
+	armh-unknown | armh-alt)
+		cpu=armv7l
+		vendor=alt
+		basic_os=${basic_os:-linux-gnueabihf}
+		;;
 	dpx20-unknown | dpx20-bull)
 		cpu=rs6000
 		vendor=bull
@@ -1104,7 +1126,7 @@ case $cpu-$vendor in
 	xscale-* | xscalee[bl]-*)
 		cpu=`echo "$cpu" | sed 's/^xscale/arm/'`
 		;;
-	arm64-*)
+	arm64-* | aarch64le-*)
 		cpu=aarch64
 		;;
 
@@ -1165,7 +1187,7 @@ case $cpu-$vendor in
 			| alphapca5[67] | alpha64pca5[67] \
 			| am33_2.0 \
 			| amdgcn \
-			| arc | arceb \
+			| arc | arceb | arc32 | arc64 \
 			| arm | arm[lb]e | arme[lb] | armv* \
 			| avr | avr32 \
 			| asmjs \
@@ -1185,6 +1207,7 @@ case $cpu-$vendor in
 			| k1om \
 			| le32 | le64 \
 			| lm32 \
+			| loongarch32 | loongarch64 \
 			| m32c | m32r | m32rle \
 			| m5200 | m68000 | m680[012346]0 | m68360 | m683?2 | m68k \
 			| m6811 | m68hc11 | m6812 | m68hc12 | m68hcs12x \
@@ -1203,9 +1226,13 @@ case $cpu-$vendor in
 			| mips64vr5900 | mips64vr5900el \
 			| mipsisa32 | mipsisa32el \
 			| mipsisa32r2 | mipsisa32r2el \
+			| mipsisa32r3 | mipsisa32r3el \
+			| mipsisa32r5 | mipsisa32r5el \
 			| mipsisa32r6 | mipsisa32r6el \
 			| mipsisa64 | mipsisa64el \
 			| mipsisa64r2 | mipsisa64r2el \
+			| mipsisa64r3 | mipsisa64r3el \
+			| mipsisa64r5 | mipsisa64r5el \
 			| mipsisa64r6 | mipsisa64r6el \
 			| mipsisa64sb1 | mipsisa64sb1el \
 			| mipsisa64sr71k | mipsisa64sr71kel \
@@ -1229,7 +1256,7 @@ case $cpu-$vendor in
 			| powerpc | powerpc64 | powerpc64le | powerpcle | powerpcspe \
 			| pru \
 			| pyramid \
-			| riscv | riscv32 | riscv64 \
+			| riscv | riscv32 | riscv32be | riscv64 | riscv64be \
 			| rl78 | romp | rs6000 | rx \
 			| s390 | s390x \
 			| score \
@@ -1241,6 +1268,7 @@ case $cpu-$vendor in
 			| sparcv8 | sparcv9 | sparcv9b | sparcv9v | sv1 | sx* \
 			| spu \
 			| tahoe \
+			| thumbv7* \
 			| tic30 | tic4x | tic54x | tic55x | tic6x | tic80 \
 			| tron \
 			| ubicom32 \
@@ -1278,34 +1306,44 @@ esac
 
 # Decode manufacturer-specific aliases for certain operating systems.
 
-if [ x$basic_os != x ]
+if test x$basic_os != x
 then
 
-# First recognize some ad-hoc caes, or perhaps split kernel-os, or else just
+# First recognize some ad-hoc cases, or perhaps split kernel-os, or else just
 # set os.
 case $basic_os in
 	gnu/linux*)
 		kernel=linux
-		os=`echo $basic_os | sed -e 's|gnu/linux|gnu|'`
+		os=`echo "$basic_os" | sed -e 's|gnu/linux|gnu|'`
+		;;
+	os2-emx)
+		kernel=os2
+		os=`echo "$basic_os" | sed -e 's|os2-emx|emx|'`
 		;;
 	nto-qnx*)
 		kernel=nto
-		os=`echo $basic_os | sed -e 's|nto-qnx|qnx|'`
+		os=`echo "$basic_os" | sed -e 's|nto-qnx|qnx|'`
 		;;
 	*-*)
 		# shellcheck disable=SC2162
+		saved_IFS=$IFS
 		IFS="-" read kernel os <<EOF
 $basic_os
 EOF
+		IFS=$saved_IFS
 		;;
 	# Default OS when just kernel was specified
 	nto*)
 		kernel=nto
-		os=`echo $basic_os | sed -e 's|nto|qnx|'`
+		os=`echo "$basic_os" | sed -e 's|nto|qnx|'`
 		;;
 	linux*)
 		kernel=linux
-		os=`echo $basic_os | sed -e 's|linux|gnu|'`
+		os=`echo "$basic_os" | sed -e 's|linux|gnu|'`
+		;;
+	managarm*)
+		kernel=managarm
+		os=`echo "$basic_os" | sed -e 's|managarm|mlibc|'`
 		;;
 	*)
 		kernel=
@@ -1326,7 +1364,7 @@ case $os in
 		os=cnk
 		;;
 	solaris1 | solaris1.*)
-		os=`echo $os | sed -e 's|solaris1|sunos4|'`
+		os=`echo "$os" | sed -e 's|solaris1|sunos4|'`
 		;;
 	solaris)
 		os=solaris2
@@ -1355,7 +1393,7 @@ case $os in
 		os=sco3.2v4
 		;;
 	sco3.2.[4-9]*)
-		os=`echo $os | sed -e 's/sco3.2./sco3.2v/'`
+		os=`echo "$os" | sed -e 's/sco3.2./sco3.2v/'`
 		;;
 	sco*v* | scout)
 		# Don't match below
@@ -1367,13 +1405,7 @@ case $os in
 		os=psos
 		;;
 	qnx*)
-		case $cpu in
-		    x86 | i*86)
-			;;
-		    *)
-			os=nto-$os
-			;;
-		esac
+		os=qnx
 		;;
 	hiux*)
 		os=hiuxwe2
@@ -1437,7 +1469,7 @@ case $os in
 		;;
 	# Preserve the version number of sinix5.
 	sinix5.*)
-		os=`echo $os | sed -e 's|sinix|sysv|'`
+		os=`echo "$os" | sed -e 's|sinix|sysv|'`
 		;;
 	sinix*)
 		os=sysv4
@@ -1683,11 +1715,14 @@ fi
 
 # Now, validate our (potentially fixed-up) OS.
 case $os in
-	# Sometimes we do "kernel-abi", so those need to count as OSes.
-	musl* | newlib* | uclibc*)
+	# Sometimes we do "kernel-libc", so those need to count as OSes.
+	musl* | newlib* | relibc* | uclibc*)
 		;;
-	# Likewise for "kernel-libc"
-	eabi | eabihf | gnueabi | gnueabihf)
+	# Likewise for "kernel-abi"
+	eabi* | gnueabi*)
+		;;
+	# VxWorks passes extra cpu info in the 4th filed.
+	simlinux | simwindows | spe)
 		;;
 	# Now accept the basic system types.
 	# The portable systems comes first.
@@ -1704,12 +1739,12 @@ case $os in
 	     | nindy* | vxsim* | vxworks* | ebmon* | hms* | mvs* \
 	     | clix* | riscos* | uniplus* | iris* | isc* | rtu* | xenix* \
 	     | mirbsd* | netbsd* | dicos* | openedition* | ose* \
-	     | bitrig* | openbsd* | solidbsd* | libertybsd* | os108* \
+	     | bitrig* | openbsd* | secbsd* | solidbsd* | libertybsd* | os108* \
 	     | ekkobsd* | freebsd* | riscix* | lynxos* | os400* \
 	     | bosx* | nextstep* | cxux* | aout* | elf* | oabi* \
 	     | ptx* | coff* | ecoff* | winnt* | domain* | vsta* \
 	     | udi* | lites* | ieee* | go32* | aux* | hcos* \
-	     | chorusrdb* | cegcc* | glidix* \
+	     | chorusrdb* | cegcc* | glidix* | serenity* \
 	     | cygwin* | msys* | pe* | moss* | proelf* | rtems* \
 	     | midipix* | mingw32* | mingw64* | mint* \
 	     | uxpv* | beos* | mpeix* | udk* | moxiebox* \
@@ -1722,13 +1757,17 @@ case $os in
 	     | skyos* | haiku* | rdos* | toppers* | drops* | es* \
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
-	     | nsk* | powerunix* | genode* | zvmoe* )
+	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
+	     | fiwix* | mlibc* )
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)
 		# Don't forget version if it is 3.2v4 or newer.
 		;;
 	none)
+		;;
+	kernel* )
+		# Restricted further below
 		;;
 	*)
 		echo Invalid configuration \`"$1"\': OS \`"$os"\' not recognized 1>&2
@@ -1739,17 +1778,34 @@ esac
 # As a final step for OS-related things, validate the OS-kernel combination
 # (given a valid OS), if there is a kernel.
 case $kernel-$os in
-	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* | linux-musl* | linux-uclibc* )
+	linux-gnu* | linux-dietlibc* | linux-android* | linux-newlib* \
+		   | linux-musl* | linux-relibc* | linux-uclibc* | linux-mlibc* )
 		;;
-	-dietlibc* | -newlib* | -musl* | -uclibc* )
+	uclinux-uclibc* )
+		;;
+	managarm-mlibc* | managarm-kernel* )
+		;;
+	-dietlibc* | -newlib* | -musl* | -relibc* | -uclibc* | -mlibc* )
 		# These are just libc implementations, not actual OSes, and thus
 		# require a kernel.
 		echo "Invalid configuration \`$1': libc \`$os' needs explicit kernel." 1>&2
 		exit 1
 		;;
+	-kernel* )
+		echo "Invalid configuration \`$1': \`$os' needs explicit kernel." 1>&2
+		exit 1
+		;;
+	*-kernel* )
+		echo "Invalid configuration \`$1': \`$kernel' does not support \`$os'." 1>&2
+		exit 1
+		;;
 	kfreebsd*-gnu* | kopensolaris*-gnu*)
 		;;
+	vxworks-simlinux | vxworks-simwindows | vxworks-spe)
+		;;
 	nto-qnx*)
+		;;
+	os2-emx)
 		;;
 	*-eabi* | *-gnueabi*)
 		;;

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # Require Autoconf 2.71 for repeatability in CI
-AC_PREREQ([2.61])
+AC_PREREQ([2.71])
 AC_INIT([OCaml],
         [OCAML__VERSION],
         [caml-list@inria.fr],

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 # Process this file with autoconf to produce a configure script.
 
 # Require Autoconf 2.71 for repeatability in CI
-AC_PREREQ([2.71])
+AC_PREREQ([2.61])
 AC_INIT([OCaml],
         [OCAML__VERSION],
         [caml-list@inria.fr],
@@ -1138,7 +1138,8 @@ AS_IF([test x"$supports_shared_libraries" = 'xtrue'],
     [aarch64-*-freebsd*], [natdynlink=true],
     [aarch64-*-openbsd*], [natdynlink=true],
     [aarch64-*-netbsd*], [natdynlink=true],
-    [riscv*-*-linux*], [natdynlink=true])])
+    [riscv*-*-linux*], [natdynlink=true],
+    [loongarch*-*-linux*], [natdynlink=true])])
 
 AS_CASE([$enable_native_toplevel,$natdynlink],
   [yes,false],
@@ -1258,7 +1259,9 @@ AS_CASE([$host],
   [x86_64-*-cygwin*],
     [has_native_backend=yes; arch=amd64; system=cygwin],
   [riscv64-*-linux*],
-    [has_native_backend=yes; arch=riscv; model=riscv64; system=linux]
+    [has_native_backend=yes; arch=riscv; model=riscv64; system=linux],
+  [loongarch64-*-linux*],
+    [has_native_backend=yes; arch=loongarch64; system=linux]
 )
 
 AS_CASE([$ccomptype],
@@ -1364,7 +1367,7 @@ default_aspp="$CC -c"
 AS_CASE([$as_target,$ocaml_cv_cc_vendor],
   [*-*-linux*,gcc-*],
     [AS_CASE([$as_cpu],
-      [x86_64|arm*|aarch64*|i[[3-6]]86|riscv*],
+      [x86_64|arm*|aarch64*|i[[3-6]]86|riscv*|loongarch*],
         [default_as="${toolpref}as"])],
   [i686-pc-windows,*],
     [default_as="ml -nologo -coff -Cp -c -Fo"

--- a/runtime/caml/stack.h
+++ b/runtime/caml/stack.h
@@ -74,6 +74,17 @@
 #define Pop_frame_pointer(sp) sp += sizeof(value)
 #endif
 
+#ifdef TARGET_loongarch64
+/* Size of the gc_regs structure, in words.
+   See loongarch64.S and loongarch64/proc.ml for the indices */
+#define Wosize_gc_regs (2 + 23 /* int regs */ + 24 /* float regs */)
+#define Saved_return_address(sp) *((intnat *)((sp) - 8))
+/* LoongArch does not use a frame pointer, but requires the stack to be
+   16-aligned, so when pushing the return address to the stack there
+   is an extra word of padding after it that needs to be skipped when
+   walking the stack. */
+#define Pop_frame_pointer(sp) sp += sizeof(value)
+#endif
 /* Declaration of variables used in the asm code */
 extern value * caml_globals[];
 extern intnat caml_globals_inited;

--- a/runtime/loongarch64.S
+++ b/runtime/loongarch64.S
@@ -1,0 +1,827 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                 OCaml                                  */
+/*                                                                        */
+/*                    yala <zhaojunchao@loongson.cn>                      */
+/*                                                                        */
+/*                   Copyright © 2008-2023 LOONGSON                       */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   $special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+/* Asm part of the runtime system, LoongArch processor, 64-bit mode */
+/* Must be preprocessed by cpp */
+
+#include "caml/m.h"
+
+#define DOMAIN_STATE_PTR $s8
+#define TRAP_PTR $s1
+#define ALLOC_PTR $s7
+#define ADDITIONAL_ARG $t2
+#define STACK_ARG_BEGIN $s3
+#define STACK_ARG_END $s4
+#define TMP $t0
+#define TMP2 $t1
+
+#define C_ARG_1 $a0
+#define C_ARG_2 $a1
+#define C_ARG_3 $a2
+#define C_ARG_4 $a3
+
+/* Support for CFI directives */
+//FIXME
+#define CFI_STARTPROC
+#define CFI_ENDPROC
+#define CFI_ADJUST(n)
+#define CFI_REGISTER(r1,r2)
+#define CFI_OFFSET(r,n)
+#define CFI_DEF_CFA_REGISTER(r)
+#define CFI_REMEMBER_STATE
+#define CFI_RESTORE_STATE
+
+        .set    domain_curr_field, 0
+        .set    domain_curr_cnt, 0
+#define DOMAIN_STATE(c_type, name) \
+        .equ    domain_field_caml_##name, domain_curr_field ; \
+        .set    domain_curr_cnt, domain_curr_cnt + 1;    \
+        .set    domain_curr_field, domain_curr_cnt*8
+#include "../runtime/caml/domain_state.tbl"
+#undef DOMAIN_STATE
+
+#define Caml_state(var) DOMAIN_STATE_PTR, domain_field_caml_##var
+
+/* Globals and labels */
+#define L(lbl) .L##lbl
+
+#define FUNCTION(name) \
+        .align 2; \
+        .globl name; \
+        .type  name, @function; \
+name:; \
+        CFI_STARTPROC
+
+#define END_FUNCTION(name) \
+        CFI_ENDPROC; \
+        .size name, .-name
+
+#if defined(__PIC__)
+#define PLT(r) %plt(r)
+#else
+#define PLT(r) r
+#endif
+
+#define OBJECT(name) \
+        .data; \
+        .align  3; \
+        .globl  name; \
+        .type   name, @object; \
+name:
+#define END_OBJECT(name) \
+        .size   name, .-name
+
+/* Stack switching operations */
+
+/* struct stack_info */
+#define Stack_sp(reg)           reg, 0
+#define Stack_exception(reg)    reg, 8
+#define Stack_handler(reg)      reg, 16
+#define Stack_handler_from_cont(reg) reg, 15
+
+/* struct c_stack_link */
+#define Cstack_stack(reg)       reg, 0
+#define Cstack_sp(reg)          reg, 8
+#define Cstack_prev(reg)        reg, 16
+
+/* struct stack_handler */
+#define Handler_value(reg)      reg, 0
+#define Handler_exception(reg)  reg, 8
+#define Handler_effect(reg)     reg, 16
+#define Handler_parent(reg)     reg, 24
+
+/* Switch from OCaml to C stack. */
+.macro SWITCH_OCAML_TO_C
+    /* Fill in Caml_state->current_stack->$sp */
+        ld.d      TMP, Caml_state(current_stack)
+        st.d      $sp, Stack_sp(TMP)
+    /* Fill in Caml_state->c_stack */
+        ld.d      TMP2, Caml_state(c_stack)
+        st.d      TMP, Cstack_stack(TMP2)
+        st.d      $sp, Cstack_sp(TMP2)
+    /* Switch to C stack */
+        move      $sp, TMP2
+        CFI_REMEMBER_STATE
+.endm
+
+/* Switch from C to OCaml stack. */
+.macro SWITCH_C_TO_OCAML
+        ld.d      $sp, Cstack_sp($sp)
+        CFI_RESTORE_STATE
+.endm
+
+/* Save all of the registers that may be in use to a free gc_regs bucket
+   and store ALLOC_PTR and TRAP_PTR back to Caml_state
+   At the end the saved registers are placed in Caml_state(gc_regs)
+ */
+.macro SAVE_ALL_REGS
+    /* First, save the young_ptr & exn_handler */
+        st.d      ALLOC_PTR, Caml_state(young_ptr)
+        st.d      TRAP_PTR, Caml_state(exn_handler)
+    /* Now, use TMP to point to the gc_regs bucket */
+        ld.d      TMP, Caml_state(gc_regs_buckets)
+		ld.d      TMP2, TMP, 0  /* next ptr */
+        st.d      TMP2, Caml_state(gc_regs_buckets)
+    /* Save allocatable integer registers Must be in
+    the same order as proc.ml int_reg_name*/
+        st.d      $a0, TMP, 2*8
+        st.d      $a1, TMP, 3*8
+        st.d      $a2, TMP, 4*8
+        st.d      $a3, TMP, 5*8
+        st.d      $a4, TMP, 6*8
+        st.d      $a5, TMP, 7*8
+        st.d      $a6, TMP, 8*8
+        st.d      $a7, TMP, 9*8
+        st.d      $s2, TMP, 10*8
+        st.d      $s3, TMP, 11*8
+        st.d      $s4, TMP, 12*8
+        st.d      $s5, TMP, 13*8
+        st.d      $s6, TMP, 14*8
+        st.d      $t2, TMP, 15*8
+        st.d      $t3, TMP, 16*8
+        st.d      $t4, TMP, 17*8
+        st.d      $t5, TMP, 18*8
+        st.d      $t6, TMP, 19*8
+        st.d      $t7, TMP, 20*8
+        st.d      $t8, TMP, 21*8
+        st.d      $s0, TMP, 22*8
+    /* Save caller-save floating-point registers
+       (callee-saves are preserved by C functions) */
+        fst.d     $ft0, TMP, 23*8
+        fst.d     $ft1, TMP, 24*8
+        fst.d     $ft2, TMP, 25*8
+        fst.d     $ft3, TMP, 26*8
+        fst.d     $ft4, TMP, 27*8
+        fst.d     $ft5, TMP, 28*8
+        fst.d     $ft6, TMP, 29*8
+        fst.d     $ft7, TMP, 30*8
+        fst.d     $fa0, TMP, 31*8
+        fst.d     $fa1, TMP, 32*8
+        fst.d     $fa2, TMP, 33*8
+        fst.d     $fa3, TMP, 34*8
+        fst.d     $fa4, TMP, 35*8
+        fst.d     $fa5, TMP, 36*8
+        fst.d     $fa6, TMP, 37*8
+        fst.d     $fa7, TMP, 38*8
+        fst.d     $ft8, TMP, 39*8
+        fst.d     $ft9, TMP, 40*8
+        fst.d     $ft10, TMP, 41*8
+        fst.d     $ft11, TMP, 42*8
+        fst.d     $ft12, TMP, 43*8
+        fst.d     $ft13, TMP, 44*8
+        fst.d     $ft14, TMP, 45*8
+        fst.d     $ft15, TMP, 46*8
+        addi.d    TMP, TMP, 16
+        st.d      TMP, Caml_state(gc_regs)
+.endm
+
+/* Undo SAVE_ALL_REGS by loading the registers saved in Caml_state(gc_regs)
+   and refreshing ALLOC_PTR & TRAP_PTR from Caml_state */
+.macro RESTORE_ALL_REGS
+    /* Restore $a0, $a1, freeing up the next ptr slot */
+        ld.d      TMP, Caml_state(gc_regs)
+        addi.d    TMP, TMP, -16
+    /* Restore registers */
+        ld.d      $a0, TMP, 2*8
+        ld.d      $a1, TMP, 3*8
+        ld.d      $a2, TMP, 4*8
+        ld.d      $a3, TMP, 5*8
+        ld.d      $a4, TMP, 6*8
+        ld.d      $a5, TMP, 7*8
+        ld.d      $a6, TMP, 8*8
+        ld.d      $a7, TMP, 9*8
+        ld.d      $s2, TMP, 10*8
+        ld.d      $s3, TMP, 11*8
+        ld.d      $s4, TMP, 12*8
+        ld.d      $s5, TMP, 13*8
+        ld.d      $s6, TMP, 14*8
+        ld.d      $t2, TMP, 15*8
+        ld.d      $t3, TMP, 16*8
+        ld.d      $t4, TMP, 17*8
+        ld.d      $t5, TMP, 18*8
+        ld.d      $t6, TMP, 19*8
+        ld.d      $t7, TMP, 20*8
+        ld.d      $t8, TMP, 21*8
+        ld.d      $s0, TMP, 22*8
+        fld.d     $ft0, TMP, 23*8
+        fld.d     $ft1, TMP, 24*8
+        fld.d     $ft2, TMP, 25*8
+        fld.d     $ft3, TMP, 26*8
+        fld.d     $ft4, TMP, 27*8
+        fld.d     $ft5, TMP, 28*8
+        fld.d     $ft6, TMP, 29*8
+        fld.d     $ft7, TMP, 30*8
+        fld.d     $fa0, TMP, 31*8
+        fld.d     $fa1, TMP, 32*8
+        fld.d     $fa2, TMP, 33*8
+        fld.d     $fa3, TMP, 34*8
+        fld.d     $fa4, TMP, 35*8
+        fld.d     $fa5, TMP, 36*8
+        fld.d     $fa6, TMP, 37*8
+        fld.d     $fa7, TMP, 38*8
+        fld.d     $ft8, TMP, 39*8
+        fld.d     $ft9, TMP, 40*8
+        fld.d     $ft10, TMP, 41*8
+        fld.d     $ft11, TMP, 42*8
+        fld.d     $ft12, TMP, 43*8
+        fld.d     $ft13, TMP, 44*8
+        fld.d     $ft14, TMP, 45*8
+        fld.d     $ft15, TMP, 46*8
+    /* Put gc_regs struct back in bucket linked list */
+        ld.d      TMP2, Caml_state(gc_regs_buckets)
+		st.d      TMP2, TMP, 0  /* next ptr */
+        st.d      TMP, Caml_state(gc_regs_buckets)
+    /* Reload new allocation pointer & exn handler */
+        ld.d      ALLOC_PTR, Caml_state(young_ptr)
+        ld.d      TRAP_PTR, Caml_state(exn_handler)
+.endm
+
+        .section        .text
+/* Invoke the garbage collector. */
+
+        .globl  caml_system__code_begin
+caml_system__code_begin:
+
+FUNCTION(caml_call_realloc_stack)
+    /* Save return address */
+        CFI_OFFSET($ra, -8)
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        //CFI_ADJUST(16)
+    /* Save all registers (including ALLOC_PTR & TRAP_PTR) */
+        SAVE_ALL_REGS
+		ld.d      C_ARG_1, $sp, 16  /* argument */
+        SWITCH_OCAML_TO_C
+        bl    PLT(caml_try_realloc_stack)
+        SWITCH_C_TO_OCAML
+        beqz    $a0, 1f
+        RESTORE_ALL_REGS
+    /* Free stack $space and return to caller */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        jr    $ra
+1:      RESTORE_ALL_REGS
+    /* Raise the Stack_overflow exception */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        addi.d    $sp, $sp, 16 /* pop argument */
+        la.global      $a0, caml_exn_Stack_overflow
+        b       caml_raise_exn
+END_FUNCTION(caml_call_realloc_stack)
+
+FUNCTION(caml_call_gc)
+L(caml_call_gc):
+    /* Save return address */
+        CFI_OFFSET($ra, -8)
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(16)
+    /* Store all registers (including ALLOC_PTR & TRAP_PTR) */
+        SAVE_ALL_REGS
+        SWITCH_OCAML_TO_C
+    /* Call the garbage collector */
+        bl    PLT(caml_garbage_collection)
+        SWITCH_C_TO_OCAML
+        RESTORE_ALL_REGS
+    /* Free stack $space and return to caller */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        jr    $ra
+END_FUNCTION(caml_call_gc)
+
+FUNCTION(caml_alloc1)
+        ld.d      TMP, Caml_state(young_limit)
+        addi.d    ALLOC_PTR, ALLOC_PTR, -16
+        bltu    ALLOC_PTR, TMP, L(caml_call_gc)
+        jr    $ra
+END_FUNCTION(caml_alloc1)
+
+FUNCTION(caml_alloc2)
+        ld.d      TMP, Caml_state(young_limit)
+        addi.d    ALLOC_PTR, ALLOC_PTR, -24
+        bltu    ALLOC_PTR, TMP, L(caml_call_gc)
+        jr    $ra
+END_FUNCTION(caml_alloc2)
+
+FUNCTION(caml_alloc3)
+        ld.d      TMP, Caml_state(young_limit)
+        addi.d    ALLOC_PTR, ALLOC_PTR, -32
+        bltu    ALLOC_PTR, TMP, L(caml_call_gc)
+        jr    $ra
+END_FUNCTION(caml_alloc3)
+
+FUNCTION(caml_allocN)
+        ld.d      TMP, Caml_state(young_limit)
+        sub.d     ALLOC_PTR, ALLOC_PTR, ADDITIONAL_ARG
+        bltu    ALLOC_PTR, TMP, L(caml_call_gc)
+        jr    $ra
+END_FUNCTION(caml_allocN)
+
+/* Call a C function from OCaml */
+/* Function to call is in ADDITIONAL_ARG */
+
+FUNCTION(caml_c_call)
+        CFI_OFFSET($ra, -8)
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(16)
+    /* Switch form OCaml to C */
+        SWITCH_OCAML_TO_C
+    /* Make the exception handler alloc ptr available to the C code */
+        st.d      ALLOC_PTR, Caml_state(young_ptr)
+        st.d      TRAP_PTR, Caml_state(exn_handler)
+    /* Call the function */
+        jirl    $ra, ADDITIONAL_ARG, 0
+    /* Reload alloc ptr */
+        ld.d      ALLOC_PTR, Caml_state(young_ptr)
+    /* Load ocaml stack */
+        SWITCH_C_TO_OCAML
+    /* Return */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        jr    $ra
+END_FUNCTION(caml_c_call)
+
+FUNCTION(caml_c_call_stack_args)
+    /* Arguments:
+        C arguments  : $a0 to a7, fa0 to fa7
+        C function   : ADDITIONAL_ARG
+        C stack args : begin=STACK_ARG_BEGIN
+                       end=STACK_ARG_END */
+        CFI_OFFSET($ra, -8)
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(16)
+    /* Switch from OCaml to C */
+        SWITCH_OCAML_TO_C
+    /* Make the exception handler alloc ptr available to the C code */
+        st.d      ALLOC_PTR, Caml_state(young_ptr)
+        st.d      TRAP_PTR, Caml_state(exn_handler)
+    /* Store $sp to restore after call */
+        move      $s2, $sp
+    /* Copy arguments from OCaml to C stack
+       NB: STACK_ARG_{BEGIN,END} are 16-byte aligned */
+1:      addi.d    STACK_ARG_END, STACK_ARG_END, -16
+        bltu    STACK_ARG_END, STACK_ARG_BEGIN, 2f
+		ld.d      TMP, STACK_ARG_END, 0 
+		ld.d      TMP2, STACK_ARG_END, 8 
+        addi.d    $sp, $sp, -16
+		st.d      TMP, $sp, 0 
+		st.d      TMP2, $sp, 8 
+        b       1b
+2:  /* Call the function */
+        jirl    $ra, ADDITIONAL_ARG, 0
+    /* Restore stack */
+        move      $sp, $s2
+    /* Reload alloc ptr */
+        ld.d      ALLOC_PTR, Caml_state(young_ptr)
+    /* Switch from C to OCaml */
+        SWITCH_C_TO_OCAML
+    /* Return */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        jr    $ra
+END_FUNCTION(caml_c_call_stack_args)
+
+/* Start the OCaml program */
+
+FUNCTION(caml_start_program)
+    /* domain state is passed as arg from C */
+        move      TMP, C_ARG_1
+        la.global      TMP2, caml_program
+
+/* Code shared with caml_callback* */
+/* Address of domain state is in TMP */
+/* Address of OCaml code to call is in TMP2 */
+/* Arguments to the OCaml code are in $a0...a7 */
+
+L(jump_to_caml):
+    /* Set up stack frame and save callee-save registers */
+        CFI_OFFSET($ra, -200)
+        addi.d    $sp, $sp, -208
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(208)
+        st.d      $s0, $sp, 2*8
+        st.d      $s1, $sp, 3*8
+        st.d      $s2, $sp, 4*8
+        st.d      $s3, $sp, 5*8
+        st.d      $s4, $sp, 6*8
+        st.d      $s5, $sp, 7*8
+        st.d      $s6, $sp, 8*8
+        st.d      $s7, $sp, 9*8
+        st.d      $s8, $sp, 10*8
+        st.d      $fp, $sp, 11*8
+        fst.d     $fs0, $sp, 14*8
+        fst.d     $fs1, $sp, 15*8
+        fst.d     $fs2, $sp, 16*8
+        fst.d     $fs3, $sp, 17*8
+        fst.d     $fs4, $sp, 18*8
+        fst.d     $fs5, $sp, 19*8
+        fst.d     $fs6, $sp, 20*8
+        fst.d     $fs7, $sp, 21*8
+    /* Load domain state pointer from argument */
+        move      DOMAIN_STATE_PTR, TMP
+    /* Reload allocation pointer */
+        ld.d      ALLOC_PTR, Caml_state(young_ptr)
+    /* Build (16-byte aligned) struct c_stack_link on the C stack */
+        ld.d      $t2, Caml_state(c_stack)
+        addi.d    $sp, $sp, -32
+        st.d      $t2, Cstack_prev($sp)
+        st.d      $zero, Cstack_stack($sp)
+        st.d      $zero, Cstack_sp($sp)
+        CFI_ADJUST(32)
+        st.d      $sp, Caml_state(c_stack)
+    /* Load the OCaml stack */
+        ld.d      $t2, Caml_state(current_stack)
+        ld.d      $t2, Stack_sp($t2)
+    /* Store the gc_regs for callbacks during a GC */
+        ld.d      $t3, Caml_state(gc_regs)
+        addi.d    $t2, $t2, -8
+		st.d      $t3, $t2, 0 
+    /* Store the stack pointer to allow DWARF unwind */
+        addi.d    $t2, $t2, -8
+		st.d      $sp, $t2, 0  /* C_stack_sp */
+    /* Setup a trap frame to catch exceptions escaping the OCaml code */
+        ld.d      $t3, Caml_state(exn_handler)
+        la.local      $t4, L(trap_handler)
+        addi.d    $t2, $t2, -16
+		st.d      $t3, $t2, 0 
+		st.d      $t4, $t2, 8 
+        move      TRAP_PTR, $t2
+    /* Switch stacks and call the OCaml code */
+        move      $sp, $t2
+        CFI_REMEMBER_STATE
+    /* Call the OCaml code */
+        jirl    $ra, TMP2, 0
+L(caml_retaddr):
+    /* Pop the trap frame, restoring Caml_state->exn_handler */
+		ld.d      $t2, $sp, 0 
+        addi.d    $sp, $sp, 16
+        CFI_ADJUST(-16)
+        st.d      $t2, Caml_state(exn_handler)
+L(return_result):
+    /* Restore GC regs */
+		ld.d      $t2, $sp, 0 
+		ld.d      $t3, $sp, 8 
+        addi.d    $sp, $sp, 16
+        CFI_ADJUST(-16)
+        st.d      $t3, Caml_state(gc_regs)
+    /* Update allocation pointer */
+        st.d      ALLOC_PTR, Caml_state(young_ptr)
+    /* Return to C stack */
+        ld.d      $t2, Caml_state(current_stack)
+        st.d      $sp, Stack_sp($t2)
+        ld.d      $t3, Caml_state(c_stack)
+        move      $sp, $t3
+        CFI_RESTORE_STATE
+    /* Pop the struct c_stack_link */
+        ld.d      $t2, Cstack_prev($sp)
+        addi.d    $sp, $sp, 32
+        CFI_ADJUST(-32)
+        st.d      $t2, Caml_state(c_stack)
+    /* Reload callee-save register and return address */
+        ld.d      $s0, $sp, 2*8
+        ld.d      $s1, $sp, 3*8
+        ld.d      $s2, $sp, 4*8
+        ld.d      $s3, $sp, 5*8
+        ld.d      $s4, $sp, 6*8
+        ld.d      $s5, $sp, 7*8
+        ld.d      $s6, $sp, 8*8
+        ld.d      $s7, $sp, 9*8
+        ld.d      $s8, $sp, 10*8
+        ld.d      $fp, $sp, 11*8
+        fld.d     $fs0, $sp, 14*8
+        fld.d     $fs1, $sp, 15*8
+        fld.d     $fs2, $sp, 16*8
+        fld.d     $fs3, $sp, 17*8
+        fld.d     $fs4, $sp, 18*8
+        fld.d     $fs5, $sp, 19*8
+        fld.d     $fs6, $sp, 20*8
+        fld.d     $fs7, $sp, 21*8
+        ld.d      $ra, $sp, 8
+        addi.d    $sp, $sp, 208
+        CFI_ADJUST(-208)
+    /* Return to C caller */
+        jr    $ra
+END_FUNCTION(caml_start_program)
+
+/* The trap handler */
+
+        .align  2
+L(trap_handler):
+        CFI_STARTPROC
+    /* Save exception pointer */
+        st.d      TRAP_PTR, Caml_state(exn_handler)
+    /* Encode exception pointer */
+        ori     $a0, $a0, 2
+    /* Return it */
+        b       L(return_result)
+        CFI_ENDPROC
+
+/* Exceptions */
+
+.macro JUMP_TO_TRAP_PTR
+    /* Cut stack at current trap handler */
+        move      $sp, TRAP_PTR
+    /* Pop previous handler and jump to it */
+		ld.d      TMP, $sp, 8 
+		ld.d      TRAP_PTR, $sp, 0 
+        addi.d    $sp, $sp, 16
+        jr      TMP
+.endm
+
+/* Raise an exception from OCaml */
+FUNCTION(caml_raise_exn)
+    /* Test if backtrace is active */
+        ld.d      TMP, Caml_state(backtrace_active)
+        bnez    TMP, 2f
+1:
+        JUMP_TO_TRAP_PTR
+2:  /* Zero backtrace_pos */
+        st.d      $zero, Caml_state(backtrace_pos)
+L(caml_reraise_exn_stash):
+    /* Preserve exception bucket in callee-save register $s2 */
+        move      $s2, $a0
+    /* Stash the backtrace */
+                                  /* arg1: exn bucket, already in $a0 */
+        move      $a1, $ra            /* arg2: pc of $raise */
+        move      $a2, $sp            /* arg3: $sp of $raise */
+        move      $a3, TRAP_PTR      /* arg4: $sp of handler */
+    /* Switch to C stack */
+        ld.d      TMP, Caml_state(c_stack)
+        move      $sp, TMP
+        bl    PLT(caml_stash_backtrace)
+    /* Restore exception bucket and $raise */
+        move      $a0, $s2
+        b       1b
+END_FUNCTION(caml_raise_exn)
+
+FUNCTION(caml_reraise_exn)
+        ld.d      TMP, Caml_state(backtrace_active)
+        bnez    TMP, L(caml_reraise_exn_stash)
+        JUMP_TO_TRAP_PTR
+END_FUNCTION(caml_reraise_exn)
+
+/* Raise an exception from C */
+
+FUNCTION(caml_raise_exception)
+    /* Load the domain state ptr */
+        move      DOMAIN_STATE_PTR, C_ARG_1
+    /* Load the exception bucket */
+        move      $a0, C_ARG_2
+    /* Reload trap ptr and alloc ptr */
+        ld.d      TRAP_PTR, Caml_state(exn_handler)
+        ld.d      ALLOC_PTR, Caml_state(young_ptr)
+    /* Discard the C stack pointer and reset to ocaml stack */
+        ld.d      TMP, Caml_state(current_stack)
+        ld.d      TMP, Stack_sp(TMP)
+        move      $sp, TMP
+    /* Restore frame and link on return to OCaml */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        b       caml_raise_exn
+END_FUNCTION(caml_raise_exception)
+
+/* Callback from C to OCaml */
+
+FUNCTION(caml_callback_asm)
+    /* Initial shuffling of arguments */
+    /* ($a0 = Caml_state, $a1 = closure, 0(a2) = first arg) */
+        move      TMP, $a0
+		ld.d      $a0, $a2, 0            /* $a0 = first arg */
+                                    /* $a1 = closure environment */
+		ld.d      TMP2, $a1, 0           /* code pointer */
+        b       L(jump_to_caml)
+END_FUNCTION(caml_callback_asm)
+
+FUNCTION(caml_callback2_asm)
+    /* Initial shuffling of arguments */
+    /* ($a0 = Caml_state, $a1 = closure, 0(a2) = arg1, 8(a2) = arg2) */
+        move      TMP, $a0
+        move      TMP2, $a1
+		ld.d      $a0, $a2, 0  /* $a0 = first arg */
+		ld.d      $a1, $a2, 8  /* $a1 = second arg */
+        move      $a2, TMP2   /* a2 = closure environment */
+        la.global      TMP2, caml_apply2
+        b       L(jump_to_caml)
+END_FUNCTION(caml_callback2_asm)
+
+FUNCTION(caml_callback3_asm)
+    /* Initial shuffling of arguments */
+    /* ($a0 = Caml_state, $a1 = closure, 0(a2) = arg1, 8(a2) = arg2,
+        16(a2) = arg3) */
+        move      TMP, $a0
+        move      $a3, $a1       /* a3 = closure environment */
+		ld.d      $a0, $a2, 0     /* $a0 = first arg */
+		ld.d      $a1, $a2, 8     /* $a1 = second arg */
+		ld.d      $a2, $a2, 16    /* a2 = third arg */
+        la.global      TMP2, caml_apply3
+        b       L(jump_to_caml)
+END_FUNCTION(caml_callback3_asm)
+
+/* Fibers */
+
+/* Switch between OCaml stacks. Clobbers TMP and switches TRAP_PTR
+   Preserves old_stack and new_stack registers */
+.macro SWITCH_OCAML_STACKS old_stack, new_stack
+    /* Save frame pointer and return address for old_stack */
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(16)
+    /* Save OCaml SP and exn_handler in the stack info */
+        st.d      $sp, Stack_sp(\old_stack)
+        st.d      TRAP_PTR, Stack_exception(\old_stack)
+    /* switch stacks */
+        st.d      \new_stack, Caml_state(current_stack)
+        ld.d      TMP, Stack_sp(\new_stack)
+        move      $sp, TMP
+    /* restore exn_handler for new stack */
+        ld.d      TRAP_PTR, Stack_exception(\new_stack)
+    /* Restore frame pointer and return address for new_stack */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+.endm
+
+/*
+ * A continuation is a one word object that points to a fiber. A fiber [f] will
+ * point to its parent at Handler_parent(Stack_handler(f)). In the following,
+ * the [last_fiber] refers to the last fiber in the linked-list formed by the
+ * parent pointer.
+ */
+
+FUNCTION(caml_perform)
+    /*  $a0: effect to perform
+        $a1: freshly allocated continuation */
+        ld.d      $a2, Caml_state(current_stack) /* a2 := old stack */
+        addi.d    $a3, $a2, 1 /* a3 := Val_ptr(old stack) */
+		st.d      $a3, $a1, 0  /* Iniitalize continuation */
+L(do_perform):
+    /*  $a0: effect to perform
+        $a1: continuation
+        a2: old_stack
+        a3: last_fiber */
+
+        ld.d      $t3, Stack_handler($a2)  /* $t3 := old stack -> handler */
+        ld.d      $t4, Handler_parent($t3) /* t4 := parent stack */
+        beqz    $t4, 1f
+        SWITCH_OCAML_STACKS $a2, $t4
+    /*  we have to null the Handler_parent after the switch because
+        the Handler_parent is needed to unwind the stack for backtraces */
+        st.d      $zero, Handler_parent($t3) /* Set parent of performer to NULL */
+        ld.d      TMP, Handler_effect($t3)
+        move      $a2, $a3                 /* a2 := last_fiber */
+        move      $a3, TMP                /* a3 := effect handler */
+        b    PLT(caml_apply3)
+1:
+    /*  switch back to original performer before $raising Effect.Unhandled
+        (no-op unless this is a reperform) */
+		ld.d      $t4, $a1, 0  /* load performer stack from continuation */
+        addi.d    $t4, $t4, -1 /* t4 := Ptr_val(t4) */
+        ld.d      $t3, Caml_state(current_stack)
+        SWITCH_OCAML_STACKS $t3, $t4
+    /*  No parent stack. Raise Effect.Unhandled. */
+        la.global      ADDITIONAL_ARG, caml_raise_unhandled_effect
+        b       caml_c_call
+END_FUNCTION(caml_perform)
+
+FUNCTION(caml_reperform)
+    /*  $a0: effect to perform
+        $a1: continuation
+        a2: last_fiber */
+        ld.d      TMP, Stack_handler_from_cont($a2)
+        ld.d      $a2, Caml_state(current_stack) /* a2 := old stack */
+        st.d      $a2, Handler_parent(TMP) /* Append to last_fiber */
+        addi.d    $a3, $a2, 1 /* a3 (last_fiber) := Val_ptr(old stack) */
+        b       L(do_perform)
+END_FUNCTION(caml_reperform)
+
+FUNCTION(caml_resume)
+    /*  $a0: new fiber
+        $a1: fun
+        a2: arg */
+        addi.d    $a0, $a0, -1 /* $a0 = Ptr_val($a0) */
+		ld.d      $a3, $a1, 0   /* code pointer */
+    /* Check if stack null, then already used */
+        beqz    $a0, 2f
+    /* Find end of list of stacks (put in $t2) */
+        move      TMP, $a0
+1:      ld.d      $t2, Stack_handler(TMP)
+        ld.d      TMP, Handler_parent($t2)
+        bnez    TMP, 1b
+    /* Add current stack to the end */
+        ld.d      $t3, Caml_state(current_stack)
+        st.d      $t3, Handler_parent($t2)
+        SWITCH_OCAML_STACKS $t3, $a0
+        move      $a0, $a2
+        jr      $a3
+2:      la.global      ADDITIONAL_ARG, caml_raise_continuation_already_resumed
+        b       caml_c_call
+END_FUNCTION(caml_resume)
+
+/* Run a function on a new stack, then either
+   return the value or invoke exception handler */
+FUNCTION(caml_runstack)
+    /*  $a0: fiber
+        $a1: fun
+        a2: arg */
+        CFI_OFFSET($ra, -8)
+        addi.d    $sp, $sp, -16
+		st.d      $ra, $sp, 8 
+        CFI_ADJUST(16)
+        addi.d    $a0, $a0, -1  /* $a0 := Ptr_val($a0) */
+		ld.d      $a3, $a1, 0    /* code pointer */
+    /*  save old stack pointer and exception handler */
+        ld.d      $t2, Caml_state(current_stack) /* $t2 := old stack */
+        st.d      $sp, Stack_sp($t2)
+        st.d      TRAP_PTR, Stack_exception($t2)
+    /* Load new stack pointer and set parent */
+        ld.d      TMP, Stack_handler($a0)
+        st.d      $t2, Handler_parent(TMP)
+        st.d      $a0, Caml_state(current_stack)
+        ld.d      $t3, Stack_sp($a0) /* $t3 := $sp of new stack */
+    /* Create an exception handler on the target stack
+       after 16byte DWARF & gc_regs block (which is unused here) */
+        addi.d    $t3, $t3, -32
+        la.local      TMP, L(fiber_exn_handler)
+		st.d      TMP, $t3, 8 
+    /* link the previous exn_handler so that copying stacks works */
+        ld.d      TMP, Stack_exception($a0)
+		st.d      TMP, $t3, 0 
+        move      TRAP_PTR, $t3
+    /* Switch to the new stack */
+        move      $sp, $t3
+        CFI_REMEMBER_STATE
+    /* Call the function on the new stack */
+        move      $a0, $a2
+        jirl    $ra, $a3, 0
+L(frame_runstack):
+        addi.d    $t2, $sp, 32 /* $t2 := stack_handler */
+        ld.d      $s2, Handler_value($t2) /* saved across C call */
+1:
+        move      $s3, $a0     /* save return across C call */
+        ld.d      $a0, Caml_state(current_stack) /* arg to caml_free_stack */
+    /* restore parent stack and exn_handler into Caml_state */
+        ld.d      TMP, Handler_parent($t2)
+        st.d      TMP, Caml_state(current_stack)
+        ld.d      TRAP_PTR, Stack_exception(TMP)
+        st.d      TRAP_PTR, Caml_state(exn_handler)
+    /* free old stack by switching directly to c_stack;
+       is a no-alloc call */
+        ld.d      $s4, Stack_sp(TMP) /* saved across C call */
+        CFI_RESTORE_STATE
+        CFI_REMEMBER_STATE
+        ld.d      TMP, Caml_state(c_stack)
+        move      $sp, TMP
+        bl    PLT(caml_free_stack)
+    /* switch directly to parent stack with correct return */
+        move      $a0, $s3
+        move      $a1, $s2
+        move      $sp, $s4
+        CFI_RESTORE_STATE
+		ld.d      TMP, $s2, 0   /* code pointer */
+    /* Invoke handle_value (or handle_exn) */
+		ld.d      $ra, $sp, 8 
+        addi.d    $sp, $sp, 16
+        CFI_ADJUST(-16)
+        jr      TMP
+L(fiber_exn_handler):
+        addi.d    $t2, $sp, 16  /* $t2 := stack_handler */
+        ld.d      $s2, Handler_exception($t2)
+        b       1b
+END_FUNCTION(caml_runstack)
+
+FUNCTION(caml_ml_array_bound_error)
+    /* Load address of [caml_array_bound_error_asm] in ADDITIONAL_ARG */
+        la.global      ADDITIONAL_ARG, caml_array_bound_error_asm
+    /* Call that function */
+        b       caml_c_call
+END_FUNCTION(caml_ml_array_bound_error)
+
+        .globl  caml_system__code_end
+caml_system__code_end:
+
+/* GC roots for callback */
+
+OBJECT(caml_system.frametable)
+        .quad   2                 /* two descriptors */
+        .quad   L(caml_retaddr)   /* return address into callback */
+        .short  -1                /* negative frame size => use callback link */
+        .short  0                 /* no roots */
+        .align  3
+        .quad   L(frame_runstack) /* return address into fiber handler */
+        .short  -1                /* negative frame size => use callback link */
+        .short  0                 /* no roots */
+        .align  3
+END_OBJECT(caml_system.frametable)
+.end

--- a/runtime/loongarch64.S
+++ b/runtime/loongarch64.S
@@ -131,7 +131,7 @@ name:
         st.d      TRAP_PTR, Caml_state(exn_handler)
     /* Now, use TMP to point to the gc_regs bucket */
         ld.d      TMP, Caml_state(gc_regs_buckets)
-		ld.d      TMP2, TMP, 0  /* next ptr */
+        ld.d      TMP2, TMP, 0  /* next ptr */
         st.d      TMP2, Caml_state(gc_regs_buckets)
     /* Save allocatable integer registers Must be in
     the same order as proc.ml int_reg_name*/
@@ -240,7 +240,7 @@ name:
         fld.d     $ft15, TMP, 46*8
     /* Put gc_regs struct back in bucket linked list */
         ld.d      TMP2, Caml_state(gc_regs_buckets)
-		st.d      TMP2, TMP, 0  /* next ptr */
+        st.d      TMP2, TMP, 0  /* next ptr */
         st.d      TMP, Caml_state(gc_regs_buckets)
     /* Reload new allocation pointer & exn handler */
         ld.d      ALLOC_PTR, Caml_state(young_ptr)
@@ -257,23 +257,23 @@ FUNCTION(caml_call_realloc_stack)
     /* Save return address */
         CFI_OFFSET($ra, -8)
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         //CFI_ADJUST(16)
     /* Save all registers (including ALLOC_PTR & TRAP_PTR) */
         SAVE_ALL_REGS
-		ld.d      C_ARG_1, $sp, 16  /* argument */
+        ld.d      C_ARG_1, $sp, 16  /* argument */
         SWITCH_OCAML_TO_C
         bl    PLT(caml_try_realloc_stack)
         SWITCH_C_TO_OCAML
         beqz    $a0, 1f
         RESTORE_ALL_REGS
     /* Free stack $space and return to caller */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         jr    $ra
 1:      RESTORE_ALL_REGS
     /* Raise the Stack_overflow exception */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         addi.d    $sp, $sp, 16 /* pop argument */
         la.global      $a0, caml_exn_Stack_overflow
@@ -285,7 +285,7 @@ L(caml_call_gc):
     /* Save return address */
         CFI_OFFSET($ra, -8)
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(16)
     /* Store all registers (including ALLOC_PTR & TRAP_PTR) */
         SAVE_ALL_REGS
@@ -295,7 +295,7 @@ L(caml_call_gc):
         SWITCH_C_TO_OCAML
         RESTORE_ALL_REGS
     /* Free stack $space and return to caller */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         jr    $ra
 END_FUNCTION(caml_call_gc)
@@ -334,7 +334,7 @@ END_FUNCTION(caml_allocN)
 FUNCTION(caml_c_call)
         CFI_OFFSET($ra, -8)
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(16)
     /* Switch form OCaml to C */
         SWITCH_OCAML_TO_C
@@ -348,7 +348,7 @@ FUNCTION(caml_c_call)
     /* Load ocaml stack */
         SWITCH_C_TO_OCAML
     /* Return */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         jr    $ra
 END_FUNCTION(caml_c_call)
@@ -361,7 +361,7 @@ FUNCTION(caml_c_call_stack_args)
                        end=STACK_ARG_END */
         CFI_OFFSET($ra, -8)
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(16)
     /* Switch from OCaml to C */
         SWITCH_OCAML_TO_C
@@ -374,11 +374,11 @@ FUNCTION(caml_c_call_stack_args)
        NB: STACK_ARG_{BEGIN,END} are 16-byte aligned */
 1:      addi.d    STACK_ARG_END, STACK_ARG_END, -16
         bltu    STACK_ARG_END, STACK_ARG_BEGIN, 2f
-		ld.d      TMP, STACK_ARG_END, 0 
-		ld.d      TMP2, STACK_ARG_END, 8 
+        ld.d      TMP, STACK_ARG_END, 0
+        ld.d      TMP2, STACK_ARG_END, 8
         addi.d    $sp, $sp, -16
-		st.d      TMP, $sp, 0 
-		st.d      TMP2, $sp, 8 
+        st.d      TMP, $sp, 0
+        st.d      TMP2, $sp, 8
         b       1b
 2:  /* Call the function */
         jirl    $ra, ADDITIONAL_ARG, 0
@@ -389,7 +389,7 @@ FUNCTION(caml_c_call_stack_args)
     /* Switch from C to OCaml */
         SWITCH_C_TO_OCAML
     /* Return */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         jr    $ra
 END_FUNCTION(caml_c_call_stack_args)
@@ -410,7 +410,7 @@ L(jump_to_caml):
     /* Set up stack frame and save callee-save registers */
         CFI_OFFSET($ra, -200)
         addi.d    $sp, $sp, -208
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(208)
         st.d      $s0, $sp, 2*8
         st.d      $s1, $sp, 3*8
@@ -448,16 +448,16 @@ L(jump_to_caml):
     /* Store the gc_regs for callbacks during a GC */
         ld.d      $t3, Caml_state(gc_regs)
         addi.d    $t2, $t2, -8
-		st.d      $t3, $t2, 0 
+        st.d      $t3, $t2, 0
     /* Store the stack pointer to allow DWARF unwind */
         addi.d    $t2, $t2, -8
-		st.d      $sp, $t2, 0  /* C_stack_sp */
+        st.d      $sp, $t2, 0  /* C_stack_sp */
     /* Setup a trap frame to catch exceptions escaping the OCaml code */
         ld.d      $t3, Caml_state(exn_handler)
         la.local      $t4, L(trap_handler)
         addi.d    $t2, $t2, -16
-		st.d      $t3, $t2, 0 
-		st.d      $t4, $t2, 8 
+        st.d      $t3, $t2, 0
+        st.d      $t4, $t2, 8
         move      TRAP_PTR, $t2
     /* Switch stacks and call the OCaml code */
         move      $sp, $t2
@@ -466,14 +466,14 @@ L(jump_to_caml):
         jirl    $ra, TMP2, 0
 L(caml_retaddr):
     /* Pop the trap frame, restoring Caml_state->exn_handler */
-		ld.d      $t2, $sp, 0 
+        ld.d      $t2, $sp, 0
         addi.d    $sp, $sp, 16
         CFI_ADJUST(-16)
         st.d      $t2, Caml_state(exn_handler)
 L(return_result):
     /* Restore GC regs */
-		ld.d      $t2, $sp, 0 
-		ld.d      $t3, $sp, 8 
+        ld.d      $t2, $sp, 0
+        ld.d      $t3, $sp, 8
         addi.d    $sp, $sp, 16
         CFI_ADJUST(-16)
         st.d      $t3, Caml_state(gc_regs)
@@ -535,8 +535,8 @@ L(trap_handler):
     /* Cut stack at current trap handler */
         move      $sp, TRAP_PTR
     /* Pop previous handler and jump to it */
-		ld.d      TMP, $sp, 8 
-		ld.d      TRAP_PTR, $sp, 0 
+        ld.d      TMP, $sp, 8
+        ld.d      TRAP_PTR, $sp, 0
         addi.d    $sp, $sp, 16
         jr      TMP
 .endm
@@ -588,7 +588,7 @@ FUNCTION(caml_raise_exception)
         ld.d      TMP, Stack_sp(TMP)
         move      $sp, TMP
     /* Restore frame and link on return to OCaml */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         b       caml_raise_exn
 END_FUNCTION(caml_raise_exception)
@@ -599,9 +599,9 @@ FUNCTION(caml_callback_asm)
     /* Initial shuffling of arguments */
     /* ($a0 = Caml_state, $a1 = closure, 0(a2) = first arg) */
         move      TMP, $a0
-		ld.d      $a0, $a2, 0            /* $a0 = first arg */
+        ld.d      $a0, $a2, 0            /* $a0 = first arg */
                                     /* $a1 = closure environment */
-		ld.d      TMP2, $a1, 0           /* code pointer */
+        ld.d      TMP2, $a1, 0           /* code pointer */
         b       L(jump_to_caml)
 END_FUNCTION(caml_callback_asm)
 
@@ -610,8 +610,8 @@ FUNCTION(caml_callback2_asm)
     /* ($a0 = Caml_state, $a1 = closure, 0(a2) = arg1, 8(a2) = arg2) */
         move      TMP, $a0
         move      TMP2, $a1
-		ld.d      $a0, $a2, 0  /* $a0 = first arg */
-		ld.d      $a1, $a2, 8  /* $a1 = second arg */
+        ld.d      $a0, $a2, 0  /* $a0 = first arg */
+        ld.d      $a1, $a2, 8  /* $a1 = second arg */
         move      $a2, TMP2   /* a2 = closure environment */
         la.global      TMP2, caml_apply2
         b       L(jump_to_caml)
@@ -623,9 +623,9 @@ FUNCTION(caml_callback3_asm)
         16(a2) = arg3) */
         move      TMP, $a0
         move      $a3, $a1       /* a3 = closure environment */
-		ld.d      $a0, $a2, 0     /* $a0 = first arg */
-		ld.d      $a1, $a2, 8     /* $a1 = second arg */
-		ld.d      $a2, $a2, 16    /* a2 = third arg */
+        ld.d      $a0, $a2, 0     /* $a0 = first arg */
+        ld.d      $a1, $a2, 8     /* $a1 = second arg */
+        ld.d      $a2, $a2, 16    /* a2 = third arg */
         la.global      TMP2, caml_apply3
         b       L(jump_to_caml)
 END_FUNCTION(caml_callback3_asm)
@@ -637,7 +637,7 @@ END_FUNCTION(caml_callback3_asm)
 .macro SWITCH_OCAML_STACKS old_stack, new_stack
     /* Save frame pointer and return address for old_stack */
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(16)
     /* Save OCaml SP and exn_handler in the stack info */
         st.d      $sp, Stack_sp(\old_stack)
@@ -649,7 +649,7 @@ END_FUNCTION(caml_callback3_asm)
     /* restore exn_handler for new stack */
         ld.d      TRAP_PTR, Stack_exception(\new_stack)
     /* Restore frame pointer and return address for new_stack */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
 .endm
 
@@ -665,7 +665,7 @@ FUNCTION(caml_perform)
         $a1: freshly allocated continuation */
         ld.d      $a2, Caml_state(current_stack) /* a2 := old stack */
         addi.d    $a3, $a2, 1 /* a3 := Val_ptr(old stack) */
-		st.d      $a3, $a1, 0  /* Iniitalize continuation */
+        st.d      $a3, $a1, 0  /* Iniitalize continuation */
 L(do_perform):
     /*  $a0: effect to perform
         $a1: continuation
@@ -686,7 +686,7 @@ L(do_perform):
 1:
     /*  switch back to original performer before $raising Effect.Unhandled
         (no-op unless this is a reperform) */
-		ld.d      $t4, $a1, 0  /* load performer stack from continuation */
+        ld.d      $t4, $a1, 0  /* load performer stack from continuation */
         addi.d    $t4, $t4, -1 /* t4 := Ptr_val(t4) */
         ld.d      $t3, Caml_state(current_stack)
         SWITCH_OCAML_STACKS $t3, $t4
@@ -711,7 +711,7 @@ FUNCTION(caml_resume)
         $a1: fun
         a2: arg */
         addi.d    $a0, $a0, -1 /* $a0 = Ptr_val($a0) */
-		ld.d      $a3, $a1, 0   /* code pointer */
+        ld.d      $a3, $a1, 0   /* code pointer */
     /* Check if stack null, then already used */
         beqz    $a0, 2f
     /* Find end of list of stacks (put in $t2) */
@@ -737,10 +737,10 @@ FUNCTION(caml_runstack)
         a2: arg */
         CFI_OFFSET($ra, -8)
         addi.d    $sp, $sp, -16
-		st.d      $ra, $sp, 8 
+        st.d      $ra, $sp, 8
         CFI_ADJUST(16)
         addi.d    $a0, $a0, -1  /* $a0 := Ptr_val($a0) */
-		ld.d      $a3, $a1, 0    /* code pointer */
+        ld.d      $a3, $a1, 0    /* code pointer */
     /*  save old stack pointer and exception handler */
         ld.d      $t2, Caml_state(current_stack) /* $t2 := old stack */
         st.d      $sp, Stack_sp($t2)
@@ -754,10 +754,10 @@ FUNCTION(caml_runstack)
        after 16byte DWARF & gc_regs block (which is unused here) */
         addi.d    $t3, $t3, -32
         la.local      TMP, L(fiber_exn_handler)
-		st.d      TMP, $t3, 8 
+        st.d      TMP, $t3, 8
     /* link the previous exn_handler so that copying stacks works */
         ld.d      TMP, Stack_exception($a0)
-		st.d      TMP, $t3, 0 
+        st.d      TMP, $t3, 0
         move      TRAP_PTR, $t3
     /* Switch to the new stack */
         move      $sp, $t3
@@ -789,9 +789,9 @@ L(frame_runstack):
         move      $a1, $s2
         move      $sp, $s4
         CFI_RESTORE_STATE
-		ld.d      TMP, $s2, 0   /* code pointer */
+        ld.d      TMP, $s2, 0   /* code pointer */
     /* Invoke handle_value (or handle_exn) */
-		ld.d      $ra, $sp, 8 
+        ld.d      $ra, $sp, 8
         addi.d    $sp, $sp, 16
         CFI_ADJUST(-16)
         jr      TMP

--- a/testsuite/tools/asmgen_loongarch64.S
+++ b/testsuite/tools/asmgen_loongarch64.S
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*                                                                        */
+/*                                OCaml                                   */
+/*                                                                        */
+/*                Nicolas Ojeda Bar <n.oje.bar@gmail.com>                 */
+/*                                                                        */
+/*   Copyright 2019 Institut National de Recherche en Informatique et     */
+/*     en Automatique.                                                    */
+/*                                                                        */
+/*   All rights reserved.  This file is distributed under the terms of    */
+/*   the GNU Lesser General Public License version 2.1, with the          */
+/*   special exception on linking described in the file LICENSE.          */
+/*                                                                        */
+/**************************************************************************/
+
+#define STORE st.d
+#define LOAD ld.d
+
+        .globl  call_gen_code
+        .align  2
+call_gen_code:
+    /* Set up stack frame and save callee-save registers */
+        addi.d    $sp, $sp, -208
+        STORE   $ra, $sp, 192
+        STORE   $s0, $sp, 0
+        STORE   $s1, $sp, 8
+        STORE   $s2, $sp, 16
+        STORE   $s3, $sp, 24
+        STORE   $s4, $sp, 32
+        STORE   $s5, $sp, 40
+        STORE   $s6, $sp, 48
+        STORE   $s7, $sp, 56
+        STORE   $s8, $sp, 64
+        fst.d     $fs0, $sp, 96
+        fst.d     $fs1, $sp, 104
+        fst.d     $fs2, $sp, 112
+        fst.d     $fs3, $sp, 120
+        fst.d     $fs4, $sp, 128
+        fst.d     $fs5, $sp, 136
+        fst.d     $fs6, $sp, 144
+        fst.d     $fs7, $sp, 152
+    /* Shuffle arguments */
+        move      $t0, $a0
+        move      $a0, $a1
+        move      $a1, $a2
+        move      $a2, $a3
+        move      $a3, $a4
+    /* Call generated asm */
+        jirl    $ra, $t0, 0
+    /* Reload callee-save registers and return address */
+        LOAD    $ra, $sp, 192
+        LOAD    $s0, $sp, 0
+        LOAD    $s1, $sp, 8
+        LOAD    $s2, $sp ,16
+        LOAD    $s3, $sp ,24
+        LOAD    $s4, $sp ,32
+        LOAD    $s5, $sp ,40
+        LOAD    $s6, $sp ,48
+        LOAD    $s7, $sp ,56
+        LOAD    $s8, $sp ,64
+        fld.d     $fs0, $sp, 96
+        fld.d     $fs1, $sp, 104
+        fld.d     $fs2, $sp, 112
+        fld.d     $fs3, $sp, 120
+        fld.d     $fs4, $sp, 128
+        fld.d     $fs5, $sp, 136
+        fld.d     $fs6, $sp, 144
+        fld.d     $fs7, $sp, 152
+        addi.d    $sp, $sp, 208
+        jr      $ra
+
+        .globl  caml_c_call
+        .align  2
+caml_c_call:
+        jr      $t2


### PR DESCRIPTION
## Abstract
Hello everyone, 
we(@MQ-mengqing @lixing-star) are the developers of loongson team, this patch we refer to riscv and arm64 in loongarch architecture adapted Ocaml, loongarch is a RISC architecture developed by loongson company, currently loongarch architecture support patch has been received by binutils, gcc, linux,qemu community.

In order to compile on the loongarch architecture, you also need to update the [config.guess](https://git.savannah.gnu.org/cgit/config.git/plain/config.guess)
## Testsuit

```
List of failed tests:
    tests/unboxed-primitive-args/'test.ml' with 1.1.1.1.1.1 (check-program-output) 

Summary:
  3330 tests passed
   63 tests skipped
    1 tests failed
  118 tests not started (parent test skipped or failed)
    0 unexpected errors
  3512 tests considered

```
The test.ml test fails due to a bug in the binutils in loongarch

## Documents
- [LoongArch Reference Manual - Volume 1: Basic Architecture: This manual describes the basic part of the LoongArch architecture.](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html)
- [LoongArch ELF psABI: This manual describes the LoongArch ELF psABI.](https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html)
- [more](https://loongson.github.io/LoongArch-Documentation/README-EN.html)